### PR TITLE
Introduce a factory method throwing Exception when no supported notifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.1.x-dev"
         }
     },
     "config": {

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -20,6 +20,11 @@ notification options. The best notifier will then be returned.
 > your system. Don't forget to add a check to avoid 'call to a member
 function of a non-object' error.
 
+If you really need to ensure a Notifier is available, you can use the
+`createOrThrowException` method. It will return the best notifier available or
+throw a `Joli\JoliNotif\Exception\NoSupportedNotifierException` if no one is
+available on the current system.
+
 ## Create your notification
 
 Create a notification is as simple as instantiating a `Notification` and

--- a/src/Exception/NoSupportedNotifierException.php
+++ b/src/Exception/NoSupportedNotifierException.php
@@ -11,31 +11,13 @@
 
 namespace Joli\JoliNotif\Exception;
 
-use Joli\JoliNotif\Notification;
-
-class InvalidNotificationException extends \LogicException implements Exception
+class NoSupportedNotifierException extends \RuntimeException implements Exception
 {
-    /**
-     * @var Notification
-     */
-    private $notification;
-
     public function __construct(
-        Notification $notification,
-        $message = '',
+        $message = 'No supported notifier',
         $code = 0,
         Exception $previous = null
     ) {
-        $this->notification = $notification;
-
         parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return Notification
-     */
-    public function getNotification()
-    {
-        return $this->notification;
     }
 }

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -11,6 +11,7 @@
 
 namespace Joli\JoliNotif;
 
+use Joli\JoliNotif\Exception\NoSupportedNotifierException;
 use Joli\JoliNotif\Notifier\AppleScriptNotifier;
 use Joli\JoliNotif\Notifier\GrowlNotifyNotifier;
 use Joli\JoliNotif\Notifier\NotifuNotifier;
@@ -33,6 +34,22 @@ class NotifierFactory
         }
 
         return self::chooseBestNotifier($notifiers);
+    }
+
+    /**
+     * @param Notifier[] $notifiers
+     *
+     * @return Notifier
+     */
+    public static function createOrThrowException(array $notifiers = [])
+    {
+        $bestNotifier = self::create($notifiers);
+
+        if (!$bestNotifier) {
+            throw new NoSupportedNotifierException();
+        }
+
+        return $bestNotifier;
     }
 
     /**

--- a/tests/NotifierFactoryTest.php
+++ b/tests/NotifierFactoryTest.php
@@ -160,4 +160,13 @@ class NotifierFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($notifier3, $notifier);
     }
+
+    /** @expectedException \Joli\JoliNotif\Exception\NoSupportedNotifierException */
+    public function testCreateOrThrowExceptionWithNoSupportedNotifiersThrowsException()
+    {
+        NotifierFactory::createOrThrowException([
+            new ConfigurableNotifier(false),
+            new ConfigurableNotifier(false),
+        ]);
+    }
 }


### PR DESCRIPTION
Currently, the `NotifierFactory#create()` method returns `null` when no notifier is supported. As this is not optimal, I propose to add a new method `NotifierFactory#createOrThrowException()` (any idea for a better name? :smile:)

Another option - which can be also implemented alongside this one - could be to return a `NullNotifier` instead of `null`.

Any thoughts?

Todo:
- [ ] Add documentation