### PR TITLE
Fixed assertion and testGetMacOSVersion test

### DIFF
--- a/src/Util/OsHelper.php
+++ b/src/Util/OsHelper.php
@@ -90,7 +90,7 @@ class OsHelper
         if (null === self::$macOSVersion) {
             $process = new Process('sw_vers -productVersion');
             $process->run();
-            self::$macOSVersion = (string) $process->getOutput();
+            self::$macOSVersion = (string) trim($process->getOutput());
         }
 
         return self::$macOSVersion;

--- a/tests/Util/OsHelperTest.php
+++ b/tests/Util/OsHelperTest.php
@@ -82,7 +82,7 @@ class OsHelperTest extends \PHPUnit_Framework_TestCase
 
         $macOsVersion = OsHelper::getMacOSVersion();
 
-        $this->assertStringMatchesFormat('%d.%d.%d', $macOsVersion);
+        $this->assertRegExp('#\d{1,2}\.\d{1,2}(\.\d{1,2})?#', $macOsVersion);
         $this->assertSame($expectedMacOsVersion, $macOsVersion);
     }
 }


### PR DESCRIPTION
This PR contains two fixes in order to fix test failures. 

1. OSX versions don't follow the current pattern and it was failing in versions like `10.10`, `9.1.2`
2. Same test doesn't work due to newline character in output. Process output value just trimmed