### PR TITLE
Require friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
-        "fabpot/php-cs-fixer": "~1.5"
+        "friendsofphp/php-cs-fixer": "~1.5"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
fabpot/php-cs-fixe is abandoned, friendsofphp/php-cs-fixer should be used instead