### PR TITLE
Added base CLI binary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bin/php-cs-fixer
 bin/phpunit
 
 .php_cs.cache
+
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ bin/php-cs-fixer
 bin/phpunit
 
 .php_cs.cache
-
-/.idea

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Discover more by reading the docs:
 * [Notification](doc/02-notification.md)
 * [Notifier](doc/03-notifier.md)
 * [Advanced usage](doc/04-advanced-usage.md)
+* [CLI usage](doc/05-cli-usage.md)
 
 You can see the current and past versions using one of the following:
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/process": "~2.3|~3.0",
+        "league/climate": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
@@ -35,5 +36,8 @@
     },
     "config": {
         "bin-dir": "bin"
-    }
+    },
+    "bin": [
+        "jolinotif"
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "symfony/process": "~2.3|~3.0",
-        "league/climate": "^3.2"
+        "symfony/process": "~2.3|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/doc/01-basic-usage.md
+++ b/doc/01-basic-usage.md
@@ -60,6 +60,7 @@ And you're done!
 * [Notification](02-notification.md)
 * [Notifier](03-notifier.md)
 * [Advanced usage](04-advanced-usage.md)
+* [CLI usage](05-cli-usage.md)
 
 Previous pages:
 

--- a/doc/02-notification.md
+++ b/doc/02-notification.md
@@ -73,6 +73,7 @@ $notification->addOption('url', 'https://google.com');
 
 * [Notifier](03-notifier.md)
 * [Advanced usage](04-advanced-usage.md)
+* [CLI usage](05-cli-usage.md)
 
 Previous pages:
 

--- a/doc/03-notifier.md
+++ b/doc/03-notifier.md
@@ -96,6 +96,7 @@ can only display icon with the .ico format.
 ## Next readings
 
 * [Advanced usage](04-advanced-usage.md)
+* [CLI usage](05-cli-usage.md)
 
 Previous pages:
 

--- a/doc/04-advanced-usage.md
+++ b/doc/04-advanced-usage.md
@@ -18,6 +18,8 @@ cronjob:
 
 ## Next readings
 
+* [CLI usage](05-cli-usage.md)
+
 Previous pages:
 
 * [Notifier](03-notifier.md)

--- a/doc/05-cli-usage.md
+++ b/doc/05-cli-usage.md
@@ -1,0 +1,35 @@
+# CLI usage
+
+## Installation
+
+Install package globally:
+
+```bash
+$ composer global require jolicode/jolinotif
+```
+**Note!** Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the transfer executable can be located by your system. Simply add this directory to your PATH in your `~/.bashrc` (or `~/.bash_profile`) like this:
+
+```
+$ echo "export PATH=~/.composer/vendor/bin:$PATH" >> ~/.bashrc
+$ source ~/.bashrc
+```
+
+## Usage
+
+To get help just run:
+```
+./jolinotif --help
+```
+
+In case of troubles use following format for passing the param: `--param="value"`.  
+For required params (title, body) equality sign and quotes can be omitted. 
+
+## Next readings
+
+Previous pages:
+
+* [Advanced usage](04-advanced-usage.md)
+* [Notifier](03-notifier.md)
+* [Notification](02-notification.md)
+* [Basic usage](01-basic-usage.md)
+* [README](../README.md)

--- a/jolinotif
+++ b/jolinotif
@@ -4,7 +4,7 @@
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\NotifierFactory;
 
-require_once('vendor/autoload.php');
+require __DIR__ . '/vendor/autoload.php';
 
 final class Cli
 {

--- a/jolinotif
+++ b/jolinotif
@@ -1,4 +1,4 @@
-#!/usr/bin/php -q
+#!/usr/bin/env php
 <?php
 
 use Joli\JoliNotif\Notification;
@@ -6,32 +6,55 @@ use Joli\JoliNotif\NotifierFactory;
 
 require_once('vendor/autoload.php');
 
-class Cli
+final class Cli
 {
-    const INFO = 0;
-    const ERROR = 1;
+    private $description = 'Send notifications to your desktop directly from your terminal.';
+    private $arguments = [];
+    private $command = [];
 
-    protected $description;
-    protected $rules = [];
-    protected $arguments = [];
+    private $rules = [
+        'title'    => [
+            'name'     => 'title',
+            'info'     => 'Notification title.',
+            'required' => true,
+        ],
+        'body'     => [
+            'name'     => 'body',
+            'info'     => 'Notification body.',
+            'required' => true,
+        ],
+        'icon'     => [
+            'name'     => 'icon',
+            'info'     => 'Notification icon.',
+            'optional' => true,
+        ],
+        'subtitle' => [
+            'name'     => 'subtitle',
+            'info'     => 'Notification subtitle. Only works on macOS (AppleScriptNotifier).',
+            'optional' => true,
+        ],
+        'sound'    => [
+            'name'     => 'sound',
+            'info'     => 'Notification sound. Only works on macOS (AppleScriptNotifier).',
+            'optional' => true,
+        ],
+        'url'      => [
+            'name'     => 'url',
+            'info'     => 'Notification url. Only works on macOS (TerminalNotifierNotifier).',
+            'optional' => true,
+        ],
+        'help'     => [
+            'name' => 'help',
+            'info' => 'Show this help.',
+            'flag' => true,
+        ],
+    ];
 
-    private $command;
-
-    /**
-     * @param string $description
-     * @param array $rules
-     */
-    public function __construct($description, array $rules)
+    public function __construct()
     {
         $this->command = $_SERVER['argv'][0];
-        $this->description = $description;
-        $this->rules = $rules;
     }
 
-    /**
-     * Main CLI arguments parser method.
-     * @throws Exception
-     */
     public function parse()
     {
         $options = '';
@@ -42,40 +65,26 @@ class Cli
             return $rule['name'] . $required . $optional;
         }, $this->rules);
 
-        $this->arguments = getopt($options, $longOptions);
+        $this->arguments = getopt($options, $longOptions) ?: [];
     }
 
-    /**
-     * Return a value of an CLI argument passed.
-     * @param string $name
-     * @return mixed
-     */
-    public function get($name)
+    public function getOption(string $name)
     {
         return $this->arguments[$name] ?: false;
     }
 
-    /**
-     * Checks if an CLI argument was passed.
-     * @param string $name
-     * @return mixed
-     */
-    public function defined($name)
+    public function hasOption(string $name)
     {
         return isset($this->arguments[$name]);
     }
 
-    /**
-     * Checks if all required were presented in arguments.
-     * @return boolean
-     */
-    public function valid()
+    public function validate()
     {
         $valid = true;
 
         foreach ($this->rules as $rule) {
-            if ($rule['required'] && !$this->defined($rule['name'])) {
-                $this->error("Please specify notification {$rule['name']}! --{$rule['name']}");
+            if ($rule['required'] && !$this->hasOption($rule['name'])) {
+                $this->log("Please specify notification {$rule['name']}! --{$rule['name']}");
                 $valid = false;
             }
         }
@@ -83,10 +92,7 @@ class Cli
         return $valid;
     }
 
-    /**
-     * Outputs CLI usage as a help.
-     */
-    public function usage()
+    public function showUsage()
     {
         $required = [];
         $optional = [];
@@ -104,65 +110,29 @@ class Cli
             $usage .= ' ' . $prefix . $this->formatUsage($name, $rule) . $postfix;
         }
 
-        $this->info($this->description);
-        $this->info(PHP_EOL . 'Usage: ' . trim($usage));
+        $this->log($this->description);
+        $this->log(PHP_EOL . 'Usage: ' . trim($usage));
 
-        $this->info(PHP_EOL . 'Required Arguments:');
+        $this->log(PHP_EOL . 'Required Arguments:');
         foreach ($required as $name => $info) {
             $value = $this->formatUsage($name, $info);
-            $this->info("\t{$value}");
-            $this->info("\t\t{$info['info']}");
+            $this->log("\t{$value}");
+            $this->log("\t\t{$info['info']}");
         }
 
-        $this->info(PHP_EOL . 'Optional Arguments:');
+        $this->log(PHP_EOL . 'Optional Arguments:');
         foreach ($optional as $name => $info) {
             $value = $this->formatUsage($name, $info);
-            $this->info("\t{$value}");
-            $this->info("\t\t{$info['info']}");
+            $this->log("\t{$value}");
+            $this->log("\t\t{$info['info']}");
         }
     }
 
-    /**
-     * Log messages to CLI output.
-     *
-     * @param integer $level
-     * @param string $message
-     */
-    private function log($level, $message)
+    public function log(string $message)
     {
-        $color = "\033[0m";
-        if ($level === self::ERROR) {
-            $color = "\033[0;31m";
-        }
-        echo $color . $message . "\033[0m" . PHP_EOL;
+        echo $message . PHP_EOL;
     }
 
-    /**
-     * Echo info message.
-     *
-     * @param string $message
-     */
-    public function info($message)
-    {
-        $this->log(self::INFO, $message);
-    }
-
-    /**
-     * Echo error message.
-     *
-     * @param string $message
-     */
-    public function error($message)
-    {
-        $this->log(self::ERROR, $message);
-    }
-
-    /**
-     * Generate usage example.
-     * @param string $name
-     * @param array $rule
-     * @return string
-     */
     private function formatUsage($name, $rule)
     {
         $example = $rule['required'] ? " {$name}" : "=\"{$name}\"";
@@ -172,91 +142,44 @@ class Cli
     }
 }
 
-$description = 'Send notifications to your desktop directly from your terminal.';
-$rules = [
-    'title'    => [
-        'name'     => 'title',
-        'info'     => 'Notification title.',
-        'required' => true,
-    ],
-    'body'     => [
-        'name'     => 'body',
-        'info'     => 'Notification body.',
-        'required' => true,
-    ],
-    'icon'     => [
-        'name'     => 'icon',
-        'info'     => 'Notification icon.',
-        'optional' => true,
-    ],
-    'subtitle' => [
-        'name'     => 'subtitle',
-        'info'     => 'Notification subtitle. Only works on macOS (AppleScriptNotifier).',
-        'optional' => true,
-    ],
-    'sound'    => [
-        'name'     => 'sound',
-        'info'     => 'Notification sound. Only works on macOS (AppleScriptNotifier).',
-        'optional' => true,
-    ],
-    'url'      => [
-        'name'     => 'url',
-        'info'     => 'Notification url. Only works on macOS (TerminalNotifierNotifier).',
-        'optional' => true,
-    ],
-    'help'     => [
-        'name' => 'help',
-        'info' => 'Show this help.',
-        'flag' => true,
-    ],
-];
+$cli = new Cli();
 
-$cli = new Cli($description, $rules);
-
-// Trying to parse args.
 try {
     $cli->parse();
 } catch (Exception $e) {
-    $cli->error($e->getMessage());
+    $cli->log($e->getMessage());
     exit(1);
 }
 
-// Checking for help.
-if ($cli->defined('help')) {
-    $cli->usage();
+if ($cli->hasOption('help')) {
+    $cli->showUsage();
     exit(0);
 }
 
-// Checking validation for required.
-if (!$cli->valid()) {
+if (!$cli->validate()) {
     exit(1);
 }
 
-// Create a Notifier.
 $notifier = NotifierFactory::create();
 
-// Create Notification.
 $notification = (new Notification())
-    ->setTitle($cli->get('title'))
-    ->setBody($cli->get('body'));
+    ->setTitle($cli->getOption('title'))
+    ->setBody($cli->getOption('body'));
 
-// Handle icon.
-if ($cli->defined('icon')) {
-    $notification->setIcon($cli->get('icon'));
+if ($cli->hasOption('icon')) {
+    $notification->setIcon($cli->getOption('icon'));
 }
 
-// Handle subtitle, sound and url.
-if ($cli->defined('subtitle')) {
-    $notification->addOption('subtitle', $cli->get('subtitle'));
+if ($cli->hasOption('subtitle')) {
+    $notification->addOption('subtitle', $cli->getOption('subtitle'));
 }
 
-if ($cli->defined('sound')) {
-    $notification->addOption('sound', $cli->get('sound'));
+if ($cli->hasOption('sound')) {
+    $notification->addOption('sound', $cli->getOption('sound'));
 }
 
-if ($cli->defined('url')) {
-    $notification->addOption('url', $cli->get('url'));
+if ($cli->hasOption('url')) {
+    $notification->addOption('url', $cli->getOption('url'));
 }
 
-// Send notification.
 $notifier->send($notification);

--- a/jolinotif
+++ b/jolinotif
@@ -3,70 +3,232 @@
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\NotifierFactory;
-use League\CLImate\CLImate;
 
 require_once('vendor/autoload.php');
 
-const VERSION = '1.0.0';
+class Cli
+{
+    const INFO = 0;
+    const ERROR = 1;
 
-$cli = new CLImate;
-$cli->description('Send notifications to your desktop directly from your terminal.');
+    protected $description;
+    protected $rules = [];
+    protected $arguments = [];
 
-$cli->arguments->add([
+    private $command;
+
+    /**
+     * @param string $description
+     * @param array $rules
+     */
+    public function __construct($description, array $rules)
+    {
+        $this->command = $_SERVER['argv'][0];
+        $this->description = $description;
+        $this->rules = $rules;
+    }
+
+    /**
+     * Main CLI arguments parser method.
+     * @throws Exception
+     */
+    public function parse()
+    {
+        $options = '';
+        $longOptions = array_map(function ($rule) {
+            $required = $rule['required'] ? ':' : '';
+            $optional = $rule['optional'] ? '::' : '';
+
+            return $rule['name'] . $required . $optional;
+        }, $this->rules);
+
+        $this->arguments = getopt($options, $longOptions);
+    }
+
+    /**
+     * Return a value of an CLI argument passed.
+     * @param string $name
+     * @return mixed
+     */
+    public function get($name)
+    {
+        return $this->arguments[$name] ?: false;
+    }
+
+    /**
+     * Checks if an CLI argument was passed.
+     * @param string $name
+     * @return mixed
+     */
+    public function defined($name)
+    {
+        return isset($this->arguments[$name]);
+    }
+
+    /**
+     * Checks if all required were presented in arguments.
+     * @return boolean
+     */
+    public function valid()
+    {
+        $valid = true;
+
+        foreach ($this->rules as $rule) {
+            if ($rule['required'] && !$this->defined($rule['name'])) {
+                $this->error("Please specify notification {$rule['name']}! --{$rule['name']}");
+                $valid = false;
+            }
+        }
+
+        return $valid;
+    }
+
+    /**
+     * Outputs CLI usage as a help.
+     */
+    public function usage()
+    {
+        $required = [];
+        $optional = [];
+        $usage = $this->command;
+
+        foreach ($this->rules as $name => $rule) {
+            $prefix = $postfix = '';
+            if ($rule['required']) {
+                $required[$name] = $rule;
+            } else {
+                $optional[$name] = $rule;
+                $prefix = '[';
+                $postfix = ']';
+            }
+            $usage .= ' ' . $prefix . $this->formatUsage($name, $rule) . $postfix;
+        }
+
+        $this->info($this->description);
+        $this->info(PHP_EOL . 'Usage: ' . trim($usage));
+
+        $this->info(PHP_EOL . 'Required Arguments:');
+        foreach ($required as $name => $info) {
+            $value = $this->formatUsage($name, $info);
+            $this->info("\t{$value}");
+            $this->info("\t\t{$info['info']}");
+        }
+
+        $this->info(PHP_EOL . 'Optional Arguments:');
+        foreach ($optional as $name => $info) {
+            $value = $this->formatUsage($name, $info);
+            $this->info("\t{$value}");
+            $this->info("\t\t{$info['info']}");
+        }
+    }
+
+    /**
+     * Log messages to CLI output.
+     *
+     * @param integer $level
+     * @param string $message
+     */
+    private function log($level, $message)
+    {
+        $color = "\033[0m";
+        if ($level === self::ERROR) {
+            $color = "\033[0;31m";
+        }
+        echo $color . $message . "\033[0m" . PHP_EOL;
+    }
+
+    /**
+     * Echo info message.
+     *
+     * @param string $message
+     */
+    public function info($message)
+    {
+        $this->log(self::INFO, $message);
+    }
+
+    /**
+     * Echo error message.
+     *
+     * @param string $message
+     */
+    public function error($message)
+    {
+        $this->log(self::ERROR, $message);
+    }
+
+    /**
+     * Generate usage example.
+     * @param string $name
+     * @param array $rule
+     * @return string
+     */
+    private function formatUsage($name, $rule)
+    {
+        $example = $rule['required'] ? " {$name}" : "=\"{$name}\"";
+        $value = $rule['flag'] ? '' : $example;
+
+        return '--' . $name . $value;
+    }
+}
+
+$description = 'Send notifications to your desktop directly from your terminal.';
+$rules = [
     'title'    => [
-        'prefix'      => 't',
-        'longPrefix'  => 'title',
-        'description' => 'Notification title.',
-        'required'    => true,
+        'name'     => 'title',
+        'info'     => 'Notification title.',
+        'required' => true,
     ],
     'body'     => [
-        'prefix'      => 'b',
-        'longPrefix'  => 'body',
-        'description' => 'Notification body.',
-        'required'    => true,
+        'name'     => 'body',
+        'info'     => 'Notification body.',
+        'required' => true,
     ],
     'icon'     => [
-        'prefix'      => 'i',
-        'longPrefix'  => 'icon',
-        'description' => 'Notification title.',
+        'name'     => 'icon',
+        'info'     => 'Notification icon.',
+        'optional' => true,
     ],
     'subtitle' => [
-        'longPrefix'  => 'subtitle',
-        'description' => 'Notification subtitle. Only works on macOS (AppleScriptNotifier).',
+        'name'     => 'subtitle',
+        'info'     => 'Notification subtitle. Only works on macOS (AppleScriptNotifier).',
+        'optional' => true,
     ],
     'sound'    => [
-        'longPrefix'  => 'sound',
-        'description' => 'Notification sound. Only works on macOS (AppleScriptNotifier).',
+        'name'     => 'sound',
+        'info'     => 'Notification sound. Only works on macOS (AppleScriptNotifier).',
+        'optional' => true,
+    ],
+    'url'      => [
+        'name'     => 'url',
+        'info'     => 'Notification url. Only works on macOS (TerminalNotifierNotifier).',
+        'optional' => true,
     ],
     'help'     => [
-        'prefix'      => 'h',
-        'longPrefix'  => 'help',
-        'description' => 'Show this help.',
+        'name' => 'help',
+        'info' => 'Show this help.',
+        'flag' => true,
     ],
-    'version'  => [
-        'prefix'      => 'v',
-        'longPrefix'  => 'version',
-        'description' => 'Show command version.',
-    ],
-]);
+];
 
-// Handle help request.
-if ($cli->arguments->defined('help')) {
+$cli = new Cli($description, $rules);
+
+// Trying to parse args.
+try {
+    $cli->parse();
+} catch (Exception $e) {
+    $cli->error($e->getMessage());
+    exit(1);
+}
+
+// Checking for help.
+if ($cli->defined('help')) {
     $cli->usage();
     exit(0);
 }
 
-// Handle version request.
-if ($cli->arguments->defined('version')) {
-    $cli->green(VERSION);
-    exit(0);
-}
-
-// Handle required params request.
-try {
-    $cli->arguments->parse();
-} catch (Exception $e) {
-    $cli->to('error')->red($e->getMessage());
+// Checking validation for required.
+if (!$cli->valid()) {
     exit(1);
 }
 
@@ -75,21 +237,25 @@ $notifier = NotifierFactory::create();
 
 // Create Notification.
 $notification = (new Notification())
-    ->setTitle($cli->arguments->get('title'))
-    ->setBody($cli->arguments->get('body'));
+    ->setTitle($cli->get('title'))
+    ->setBody($cli->get('body'));
 
 // Handle icon.
-if ($cli->arguments->defined('icon')) {
-    $notification->setIcon($cli->arguments->get('icon'));
+if ($cli->defined('icon')) {
+    $notification->setIcon($cli->get('icon'));
 }
 
-// Handle subtitle and sound.
-if ($cli->arguments->defined('subtitle')) {
-    $notification->addOption('subtitle', $cli->arguments->get('subtitle'));
+// Handle subtitle, sound and url.
+if ($cli->defined('subtitle')) {
+    $notification->addOption('subtitle', $cli->get('subtitle'));
 }
 
-if ($cli->arguments->defined('sound')) {
-    $notification->addOption('sound', $cli->arguments->get('sound'));
+if ($cli->defined('sound')) {
+    $notification->addOption('sound', $cli->get('sound'));
+}
+
+if ($cli->defined('url')) {
+    $notification->addOption('url', $cli->get('url'));
 }
 
 // Send notification.

--- a/jolinotif
+++ b/jolinotif
@@ -1,0 +1,95 @@
+#!/usr/bin/php -q
+<?php
+
+use Joli\JoliNotif\Notification;
+use Joli\JoliNotif\NotifierFactory;
+use League\CLImate\CLImate;
+
+require_once('vendor/autoload.php');
+
+const VERSION = '1.0.0';
+
+$cli = new CLImate;
+$cli->description('Send notifications to your desktop directly from your terminal.');
+
+$cli->arguments->add([
+    'title'    => [
+        'prefix'      => 't',
+        'longPrefix'  => 'title',
+        'description' => 'Notification title.',
+        'required'    => true,
+    ],
+    'body'     => [
+        'prefix'      => 'b',
+        'longPrefix'  => 'body',
+        'description' => 'Notification body.',
+        'required'    => true,
+    ],
+    'icon'     => [
+        'prefix'      => 'i',
+        'longPrefix'  => 'icon',
+        'description' => 'Notification title.',
+    ],
+    'subtitle' => [
+        'longPrefix'  => 'subtitle',
+        'description' => 'Notification subtitle. Only works on macOS (AppleScriptNotifier).',
+    ],
+    'sound'    => [
+        'longPrefix'  => 'sound',
+        'description' => 'Notification sound. Only works on macOS (AppleScriptNotifier).',
+    ],
+    'help'     => [
+        'prefix'      => 'h',
+        'longPrefix'  => 'help',
+        'description' => 'Show this help.',
+    ],
+    'version'  => [
+        'prefix'      => 'v',
+        'longPrefix'  => 'version',
+        'description' => 'Show command version.',
+    ],
+]);
+
+// Handle help request.
+if ($cli->arguments->defined('help')) {
+    $cli->usage();
+    exit(0);
+}
+
+// Handle version request.
+if ($cli->arguments->defined('version')) {
+    $cli->green(VERSION);
+    exit(0);
+}
+
+// Handle required params request.
+try {
+    $cli->arguments->parse();
+} catch (Exception $e) {
+    $cli->to('error')->red($e->getMessage());
+}
+
+// Create a Notifier.
+$notifier = NotifierFactory::create();
+
+// Create Notification.
+$notification = (new Notification())
+    ->setTitle($cli->arguments->get('title'))
+    ->setBody($cli->arguments->get('body'));
+
+// Handle icon.
+if ($cli->arguments->defined('icon')) {
+    $notification->setIcon($cli->arguments->get('icon'));
+}
+
+// Handle subtitle and sound.
+if ($cli->arguments->defined('subtitle')) {
+    $notification->addOption('subtitle', $cli->arguments->get('subtitle'));
+}
+
+if ($cli->arguments->defined('sound')) {
+    $notification->addOption('sound', $cli->arguments->get('sound'));
+}
+
+// Send notification.
+$notifier->send($notification);

--- a/jolinotif
+++ b/jolinotif
@@ -67,6 +67,7 @@ try {
     $cli->arguments->parse();
 } catch (Exception $e) {
     $cli->to('error')->red($e->getMessage());
+    exit(1);
 }
 
 // Create a Notifier.


### PR DESCRIPTION
Added base CLI implementation (#29). But I think better to move it into separate repo, somethig like `jolicode/jolinotif-cli`.

### Installation

Install package globally:

```bash
$ composer global require jolicode/jolinotif
```
**Note!** Make sure to place the `~/.composer/vendor/bin` directory (or the equivalent directory for your OS) in your PATH so the transfer executable can be located by your system. Simply add this directory to your PATH in your `~/.bashrc` (or `~/.bash_profile`) like this:

```
$ echo "export PATH=~/.composer/vendor/bin:$PATH" >> ~/.bashrc
$ source ~/.bashrc
```