### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/process": "~2.3|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~4.8.35",
         "friendsofphp/php-cs-fixer": "~2.0"
     },
     "extra": {

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -12,8 +12,9 @@
 namespace Joli\JoliNotif\tests;
 
 use Joli\JoliNotif\Notification;
+use PHPUnit\Framework\TestCase;
 
-class NotificationTest extends \PHPUnit_Framework_TestCase
+class NotificationTest extends TestCase
 {
     public function testItExtractsIconFromPhar()
     {

--- a/tests/Notifier/NotifierTestCase.php
+++ b/tests/Notifier/NotifierTestCase.php
@@ -12,8 +12,9 @@
 namespace Joli\JoliNotif\tests\Notifier;
 
 use Joli\JoliNotif\Notifier;
+use PHPUnit\Framework\TestCase;
 
-abstract class NotifierTestCase extends \PHPUnit_Framework_TestCase
+abstract class NotifierTestCase extends TestCase
 {
     /**
      * @return Notifier

--- a/tests/NotifierFactoryTest.php
+++ b/tests/NotifierFactoryTest.php
@@ -15,8 +15,9 @@ use Joli\JoliNotif\Notifier\NullNotifier;
 use Joli\JoliNotif\NotifierFactory;
 use Joli\JoliNotif\tests\fixtures\ConfigurableNotifier;
 use Joli\JoliNotif\Util\OsHelper;
+use PHPUnit\Framework\TestCase;
 
-class NotifierFactoryTest extends \PHPUnit_Framework_TestCase
+class NotifierFactoryTest extends TestCase
 {
     public function testGetDefaultNotifiers()
     {

--- a/tests/Util/OsHelperTest.php
+++ b/tests/Util/OsHelperTest.php
@@ -12,8 +12,9 @@
 namespace Joli\JoliNotif\tests\Util;
 
 use Joli\JoliNotif\Util\OsHelper;
+use PHPUnit\Framework\TestCase;
 
-class OsHelperTest extends \PHPUnit_Framework_TestCase
+class OsHelperTest extends TestCase
 {
     public function testIsUnix()
     {

--- a/tests/Util/PharExtractorTest.php
+++ b/tests/Util/PharExtractorTest.php
@@ -12,8 +12,9 @@
 namespace Joli\JoliNotif\tests\Util;
 
 use Joli\JoliNotif\Util\PharExtractor;
+use PHPUnit\Framework\TestCase;
 
-class PharExtractorTest extends \PHPUnit_Framework_TestCase
+class PharExtractorTest extends TestCase
 {
     public function testIsLocatedInsideAPhar()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.