### PR TITLE
Add compatibility with Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,47 @@
 language: php
 
+php:
+    - 7.0
+    - 7.1
+    - 7.2
+
+env:
+    global:
+        - TARGET=test
+        - SYMFONY_PHPUNIT_REMOVE="symfony/yaml"
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.0
+          env: TARGET=cs_dry_run
+        - php: 7.0
+          env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
+        # test 3.4 LTS
+        - php: 7.0
+          env: SYMFONY_VERSION=3.4.*
+        # test the latest stable 4.x release
+        - php: 7.1
+          env: SYMFONY_VERSION=^4.0
+        # test the latest release (including beta releases)
+        - php: 7.2
+          env: DEPENDENCIES=beta
+
 sudo: false
 
 cache:
     directories:
         - $HOME/.composer/cache
 
-matrix:
-    include:
-        - php: hhvm
-        - php: 5.4
-          env: check_cs=true
-        - php: 5.5
-        - php: 5.6
-          env: deps=low
-        - php: 5.6
-          env: deps=high
-        - php: 7.0
-    allow_failures:
-        - php: hhvm
+before_install:
+    - if [ "$DEPENDENCIES" = "beta" ]; then perl -pi -e 's/^}$/,"minimum-stability":"beta"}/' composer.json; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
 
-env:
-    global:
-        - deps=high
-        - check_cs=false
-
-install:
-    - if [ "$deps" = "low" ]; then composer --prefer-dist --prefer-lowest update; fi;
-    - if [ "$deps" != "low" ]; then composer --prefer-dist update; fi;
-
-before_script:
-    - composer install --no-interaction
+install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
-    - ./vendor/bin/phpunit
-    - if [ "$check_cs" = "true" ]; then vendor/bin/php-cs-fixer fix --config=.php_cs --dry-run --diff; fi;
+    - make $TARGET
 
 branches:
     only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes between versions
 
+## Not yet released
+
+* Dropped support for Symfony < 3.3
+* Dropped support for PHP < 7 & HHVM
+* Fixed compatibility with Symfony 4
+* Added better CI configuration
+* Added typehints everywhere
+
 ## 1.3.0 (2018-01-25)
 
 * Added binary script to run jolinotif in CLI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ changes, improvements or alternatives may be given).
 Run the tests using the following script:
 
 ```shell
-vendor/bin/phpunit
+make test
 ```
 
 ## Standard code
@@ -57,7 +57,7 @@ Use [PHP CS fixer](http://cs.sensiolabs.org/) to make your code compliant with
 JoliNotif's coding standards:
 
 ```shell
-vendor/bin/php-cs-fixer fix .
+make cs
 ```
 
 ## Keeping your fork up-to-date

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-cs:
+cs: ## Fix CS violations
 	./vendor/bin/php-cs-fixer fix --verbose
 
-cs_dry_run:
+cs_dry_run: ## Display CS violations without fixing it
 	./vendor/bin/php-cs-fixer fix --verbose --dry-run
 
-test:
+test: ## Run test suite
 	./vendor/bin/simple-phpunit
+
+.PHONY: help
+
+help: ## Display this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+cs:
+	./vendor/bin/php-cs-fixer fix --verbose
+
+cs_dry_run:
+	./vendor/bin/php-cs-fixer fix --verbose --dry-run
+
+test:
+	./vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.4.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         }
     },
     "require": {
-        "php": ">=5.4.0",
-        "symfony/process": "~2.3|~3.0"
+        "php": ">=7.0",
+        "symfony/process": "~3.3|~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35",
-        "friendsofphp/php-cs-fixer": "~2.0"
+        "friendsofphp/php-cs-fixer": "~2.0",
+        "symfony/phpunit-bridge": "^3.3"
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     },
     "bin": [

--- a/jolinotif
+++ b/jolinotif
@@ -10,8 +10,7 @@ final class Cli
 {
     const DESCRIPTION = 'Send notifications to your desktop directly from your terminal.';
 
-    // Move to a constant when PHP required version is bumped to PHP >= 5.6
-    private static $rules = [
+    const RULES = [
         'title'    => [
             'name'     => 'title',
             'info'     => 'Notification title.',
@@ -65,7 +64,7 @@ final class Cli
             $flag = $rule['required'] ? ':' : '::';
 
             return $rule['name'] . $flag;
-        }, self::$rules);
+        }, self::RULES);
 
         $this->arguments = getopt($options, $longOptions) ?: [];
     }
@@ -84,7 +83,7 @@ final class Cli
     {
         $valid = true;
 
-        foreach (self::$rules as $rule) {
+        foreach (self::RULES as $rule) {
             if ($rule['required'] && !$this->hasOption($rule['name'])) {
                 $this->log("Please specify notification {$rule['name']} with the option --{$rule['name']}");
                 $valid = false;
@@ -100,7 +99,7 @@ final class Cli
         $optional = [];
         $usage = $this->command;
 
-        foreach (self::$rules as $name => $rule) {
+        foreach (self::RULES as $name => $rule) {
             $prefix = $postfix = '';
             if ($rule['required']) {
                 $required[$name] = $rule;

--- a/src/Exception/InvalidNotificationException.php
+++ b/src/Exception/InvalidNotificationException.php
@@ -31,10 +31,7 @@ class InvalidNotificationException extends \LogicException implements Exception
         parent::__construct($message, $code, $previous);
     }
 
-    /**
-     * @return Notification
-     */
-    public function getNotification()
+    public function getNotification(): Notification
     {
         return $this->notification;
     }

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -16,17 +16,17 @@ use Joli\JoliNotif\Util\PharExtractor;
 class Notification
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $title;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $body;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $icon;
 
@@ -36,19 +36,14 @@ class Notification
     private $options = [];
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle()
     {
         return $this->title;
     }
 
-    /**
-     * @param string $title
-     *
-     * @return $this
-     */
-    public function setTitle($title)
+    public function setTitle(string $title): self
     {
         $this->title = $title;
 
@@ -56,19 +51,14 @@ class Notification
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBody()
     {
         return $this->body;
     }
 
-    /**
-     * @param string $body
-     *
-     * @return $this
-     */
-    public function setBody($body)
+    public function setBody(string $body): self
     {
         $this->body = $body;
 
@@ -76,19 +66,14 @@ class Notification
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getIcon()
     {
         return $this->icon;
     }
 
-    /**
-     * @param string $icon
-     *
-     * @return $this
-     */
-    public function setIcon($icon)
+    public function setIcon(string $icon): self
     {
         // This makes the icon accessible for native commands when it's embedded inside a phar
         if (PharExtractor::isLocatedInsideAPhar($icon)) {
@@ -104,11 +89,9 @@ class Notification
     }
 
     /**
-     * @param string $key
-     *
-     * @return string
+     * @return string|null
      */
-    public function getOption($key)
+    public function getOption(string $key)
     {
         if (!array_key_exists($key, $this->options)) {
             return null;
@@ -117,13 +100,7 @@ class Notification
         return $this->options[$key];
     }
 
-    /**
-     * @param string $key
-     * @param string $option
-     *
-     * @return $this
-     */
-    public function addOption($key, $option)
+    public function addOption(string $key, string $option): self
     {
         $this->options[$key] = $option;
 

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -20,26 +20,18 @@ interface Notifier
     /**
      * This method is called to check whether the notifier can be used on the
      * current system or not.
-     *
-     * @return bool
      */
-    public function isSupported();
+    public function isSupported(): bool;
 
     /**
      * The supported notifier with the higher priority will be preferred.
-     *
-     * @return int
      */
-    public function getPriority();
+    public function getPriority(): int;
 
     /**
      * Send the given notification.
      *
-     * @param Notification $notification
-     *
      * @throws Exception\InvalidNotificationException if the notification is invalid
-     *
-     * @return bool
      */
-    public function send(Notification $notification);
+    public function send(Notification $notification): bool;
 }

--- a/src/Notifier/AppleScriptNotifier.php
+++ b/src/Notifier/AppleScriptNotifier.php
@@ -13,7 +13,6 @@ namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Util\OsHelper;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on Mac OS X 10.9+.
@@ -23,7 +22,7 @@ class AppleScriptNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         if (OsHelper::isMacOS() && version_compare(OsHelper::getMacOSVersion(), '10.9.0', '>=')) {
             return parent::isSupported();
@@ -35,7 +34,7 @@ class AppleScriptNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'osascript';
     }
@@ -43,7 +42,7 @@ class AppleScriptNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_LOW;
     }
@@ -51,7 +50,7 @@ class AppleScriptNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
         $script = 'display notification "'.str_replace('"', '\\"', $notification->getBody()).'"';
 
@@ -67,7 +66,9 @@ class AppleScriptNotifier extends CliBasedNotifier
             $script .= ' sound name "'.str_replace('"', '\\"', $notification->getOption('sound')).'"';
         }
 
-        $processBuilder->add('-e');
-        $processBuilder->add($script);
+        return [
+            '-e',
+            $script,
+        ];
     }
 }

--- a/src/Notifier/BinaryProvider.php
+++ b/src/Notifier/BinaryProvider.php
@@ -19,34 +19,26 @@ interface BinaryProvider
 {
     /**
      * Return whether the embedded binary can be used on the current system.
-     *
-     * @return bool
      */
-    public function canBeUsed();
+    public function canBeUsed(): bool;
 
     /**
      * Return the absolute path of the directory containing all the files.
-     *
-     * @return string
      */
-    public function getRootDir();
+    public function getRootDir(): string;
 
     /**
      * Return the path of the embedded binary.
      *
      * The path should be relative to the directory pointed by getRootDir().
-     *
-     * @return array
      */
-    public function getEmbeddedBinary();
+    public function getEmbeddedBinary(): string;
 
     /**
      * Return an array of files that should be extracted when JoliNotif is
      * used inside a phar archive.
      *
      * All paths should be relative to the directory pointed by getRootDir().
-     *
-     * @return array
      */
-    public function getExtraFiles();
+    public function getExtraFiles(): array;
 }

--- a/src/Notifier/GrowlNotifyNotifier.php
+++ b/src/Notifier/GrowlNotifyNotifier.php
@@ -12,7 +12,6 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on Mac OS X when growlnotify command is available.
@@ -22,7 +21,7 @@ class GrowlNotifyNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'growlnotify';
     }
@@ -30,7 +29,7 @@ class GrowlNotifyNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_HIGH;
     }
@@ -38,19 +37,23 @@ class GrowlNotifyNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
-        $processBuilder->add('--message');
-        $processBuilder->add($notification->getBody());
+        $arguments = [
+            '--message',
+            $notification->getBody(),
+        ];
 
         if ($notification->getTitle()) {
-            $processBuilder->add('--title');
-            $processBuilder->add($notification->getTitle());
+            $arguments[] = '--title';
+            $arguments[] = $notification->getTitle();
         }
 
         if ($notification->getIcon()) {
-            $processBuilder->add('--image');
-            $processBuilder->add($notification->getIcon());
+            $arguments[] = '--image';
+            $arguments[] = $notification->getIcon();
         }
+
+        return $arguments;
     }
 }

--- a/src/Notifier/NotifuNotifier.php
+++ b/src/Notifier/NotifuNotifier.php
@@ -13,7 +13,6 @@ namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Util\OsHelper;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on Windows Seven and provides its own binaries if
@@ -24,7 +23,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'notifu';
     }
@@ -32,7 +31,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_LOW;
     }
@@ -40,7 +39,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function canBeUsed()
+    public function canBeUsed(): bool
     {
         return OsHelper::isWindows() && OsHelper::isWindowsSeven();
     }
@@ -48,7 +47,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getRootDir()
+    public function getRootDir(): string
     {
         return dirname(dirname(__DIR__)).'/bin/notifu';
     }
@@ -56,7 +55,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getEmbeddedBinary()
+    public function getEmbeddedBinary(): string
     {
         return 'notifu.exe';
     }
@@ -64,7 +63,7 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getExtraFiles()
+    public function getExtraFiles(): array
     {
         return [];
     }
@@ -72,19 +71,23 @@ class NotifuNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
-        $processBuilder->add('/m');
-        $processBuilder->add($notification->getBody());
+        $arguments = [
+            '/m',
+            $notification->getBody(),
+        ];
 
         if ($notification->getTitle()) {
-            $processBuilder->add('/p');
-            $processBuilder->add($notification->getTitle());
+            $arguments[] = '/p';
+            $arguments[] = $notification->getTitle();
         }
 
         if ($notification->getIcon()) {
-            $processBuilder->add('/i');
-            $processBuilder->add($notification->getIcon());
+            $arguments[] = '/i';
+            $arguments[] = $notification->getIcon();
         }
+
+        return $arguments;
     }
 }

--- a/src/Notifier/NotifySendNotifier.php
+++ b/src/Notifier/NotifySendNotifier.php
@@ -12,7 +12,6 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on most Linux distributions, using the command notify-send.
@@ -23,7 +22,7 @@ class NotifySendNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'notify-send';
     }
@@ -31,7 +30,7 @@ class NotifySendNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_MEDIUM;
     }
@@ -39,17 +38,21 @@ class NotifySendNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
+        $arguments = [];
+
         if ($notification->getIcon()) {
-            $processBuilder->add('--icon');
-            $processBuilder->add($notification->getIcon());
+            $arguments[] = '--icon';
+            $arguments[] = $notification->getIcon();
         }
 
         if ($notification->getTitle()) {
-            $processBuilder->add($notification->getTitle());
+            $arguments[] = $notification->getTitle();
         }
 
-        $processBuilder->add($notification->getBody());
+        $arguments[] = $notification->getBody();
+
+        return $arguments;
     }
 }

--- a/src/Notifier/NullNotifier.php
+++ b/src/Notifier/NullNotifier.php
@@ -19,7 +19,7 @@ class NullNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return true;
     }
@@ -27,7 +27,7 @@ class NullNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_LOW;
     }
@@ -35,7 +35,7 @@ class NullNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function send(Notification $notification)
+    public function send(Notification $notification): bool
     {
         return false;
     }

--- a/src/Notifier/TerminalNotifierNotifier.php
+++ b/src/Notifier/TerminalNotifierNotifier.php
@@ -13,7 +13,6 @@ namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Util\OsHelper;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on Mac OS X 10.8, or higher, using the
@@ -24,7 +23,7 @@ class TerminalNotifierNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'terminal-notifier';
     }
@@ -32,7 +31,7 @@ class TerminalNotifierNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_MEDIUM;
     }
@@ -40,24 +39,28 @@ class TerminalNotifierNotifier extends CliBasedNotifier
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
-        $processBuilder->add('-message');
-        $processBuilder->add($notification->getBody());
+        $arguments = [
+            '-message',
+            $notification->getBody(),
+        ];
 
         if ($notification->getTitle()) {
-            $processBuilder->add('-title');
-            $processBuilder->add($notification->getTitle());
+            $arguments[] = '-title';
+            $arguments[] = $notification->getTitle();
         }
 
         if ($notification->getIcon() && version_compare(OsHelper::getMacOSVersion(), '10.9.0', '>=')) {
-            $processBuilder->add('-appIcon');
-            $processBuilder->add($notification->getIcon());
+            $arguments[] = '-appIcon';
+            $arguments[] = $notification->getIcon();
         }
 
         if ($notification->getOption('url')) {
-            $processBuilder->add('-open');
-            $processBuilder->add($notification->getOption('url'));
+            $arguments[] = '-open';
+            $arguments[] = $notification->getOption('url');
         }
+
+        return $arguments;
     }
 }

--- a/src/Notifier/ToasterNotifier.php
+++ b/src/Notifier/ToasterNotifier.php
@@ -13,7 +13,6 @@ namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Util\OsHelper;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * This notifier can be used on Windows Eight and higher and provides its own
@@ -24,7 +23,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getBinary()
+    public function getBinary(): string
     {
         return 'toast';
     }
@@ -32,7 +31,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return static::PRIORITY_MEDIUM;
     }
@@ -40,7 +39,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function canBeUsed()
+    public function canBeUsed(): bool
     {
         return OsHelper::isWindows() && OsHelper::isWindowsEightOrHigher();
     }
@@ -48,7 +47,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getRootDir()
+    public function getRootDir(): string
     {
         return dirname(dirname(__DIR__)).'/bin/toaster';
     }
@@ -56,7 +55,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getEmbeddedBinary()
+    public function getEmbeddedBinary(): string
     {
         return 'toast.exe';
     }
@@ -64,7 +63,7 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    public function getExtraFiles()
+    public function getExtraFiles(): array
     {
         return [
             'Microsoft.WindowsAPICodePack.dll',
@@ -75,19 +74,23 @@ class ToasterNotifier extends CliBasedNotifier implements BinaryProvider
     /**
      * {@inheritdoc}
      */
-    protected function configureProcess(ProcessBuilder $processBuilder, Notification $notification)
+    protected function getCommandLineArguments(Notification $notification): array
     {
-        $processBuilder->add('-m');
-        $processBuilder->add($notification->getBody());
+        $arguments = [
+            '-m',
+            $notification->getBody(),
+        ];
 
         if ($notification->getTitle()) {
-            $processBuilder->add('-t');
-            $processBuilder->add($notification->getTitle());
+            $arguments[] = '-t';
+            $arguments[] = $notification->getTitle();
         }
 
         if ($notification->getIcon()) {
-            $processBuilder->add('-p');
-            $processBuilder->add($notification->getIcon());
+            $arguments[] = '-p';
+            $arguments[] = $notification->getIcon();
         }
+
+        return $arguments;
     }
 }

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -25,10 +25,8 @@ class NotifierFactory
 {
     /**
      * @param Notifier[] $notifiers
-     *
-     * @return Notifier
      */
-    public static function create(array $notifiers = [])
+    public static function create(array $notifiers = []): Notifier
     {
         if (empty($notifiers)) {
             $notifiers = static::getDefaultNotifiers();
@@ -45,10 +43,8 @@ class NotifierFactory
 
     /**
      * @param Notifier[] $notifiers
-     *
-     * @return Notifier
      */
-    public static function createOrThrowException(array $notifiers = [])
+    public static function createOrThrowException(array $notifiers = []): Notifier
     {
         if (empty($notifiers)) {
             $notifiers = static::getDefaultNotifiers();
@@ -66,7 +62,7 @@ class NotifierFactory
     /**
      * @return Notifier[]
      */
-    public static function getDefaultNotifiers()
+    public static function getDefaultNotifiers(): array
     {
         // Don't retrieve notifiers which are certainly not supported on this
         // system. This helps to lower the number of process to run.
@@ -80,7 +76,7 @@ class NotifierFactory
     /**
      * @return Notifier[]
      */
-    private static function getUnixNotifiers()
+    private static function getUnixNotifiers(): array
     {
         return [
             new GrowlNotifyNotifier(),
@@ -93,7 +89,7 @@ class NotifierFactory
     /**
      * @return Notifier[]
      */
-    private static function getWindowsNotifiers()
+    private static function getWindowsNotifiers(): array
     {
         return [
             new ToasterNotifier(),
@@ -106,7 +102,7 @@ class NotifierFactory
      *
      * @return Notifier|null
      */
-    private static function chooseBestNotifier($notifiers)
+    private static function chooseBestNotifier(array $notifiers)
     {
         /** @var Notifier|null $bestNotifier */
         $bestNotifier = null;

--- a/src/Util/OsHelper.php
+++ b/src/Util/OsHelper.php
@@ -30,26 +30,17 @@ class OsHelper
      */
     private static $macOSVersion;
 
-    /**
-     * @return bool
-     */
-    public static function isUnix()
+    public static function isUnix(): bool
     {
         return '/' === DIRECTORY_SEPARATOR;
     }
 
-    /**
-     * @return bool
-     */
-    public static function isWindows()
+    public static function isWindows(): bool
     {
         return '\\' === DIRECTORY_SEPARATOR;
     }
 
-    /**
-     * @return bool
-     */
-    public static function isWindowsSeven()
+    public static function isWindowsSeven(): bool
     {
         if (null === self::$kernelVersion) {
             self::$kernelVersion = php_uname('r');
@@ -58,10 +49,7 @@ class OsHelper
         return '6.1' === self::$kernelVersion;
     }
 
-    /**
-     * @return bool
-     */
-    public static function isWindowsEightOrHigher()
+    public static function isWindowsEightOrHigher(): bool
     {
         if (null === self::$kernelVersion) {
             self::$kernelVersion = php_uname('r');
@@ -70,10 +58,7 @@ class OsHelper
         return version_compare(self::$kernelVersion, '6.2', '>=');
     }
 
-    /**
-     * @return bool
-     */
-    public static function isMacOS()
+    public static function isMacOS(): bool
     {
         if (null === self::$kernelName) {
             self::$kernelName = php_uname('s');
@@ -82,10 +67,7 @@ class OsHelper
         return false !== strpos(self::$kernelName, 'Darwin');
     }
 
-    /**
-     * @return string
-     */
-    public static function getMacOSVersion()
+    public static function getMacOSVersion(): string
     {
         if (null === self::$macOSVersion) {
             $process = new Process('sw_vers -productVersion');

--- a/src/Util/PharExtractor.php
+++ b/src/Util/PharExtractor.php
@@ -15,12 +15,8 @@ class PharExtractor
 {
     /**
      * Return whether the file path is located inside a phar.
-     *
-     * @param string $filePath
-     *
-     * @return bool
      */
-    public static function isLocatedInsideAPhar($filePath)
+    public static function isLocatedInsideAPhar(string $filePath): bool
     {
         return 0 === strpos($filePath, 'phar://');
     }
@@ -28,12 +24,9 @@ class PharExtractor
     /**
      * Extract the file from the phar archive to make it accessible for native commands.
      *
-     * @param string $filePath  the absolute file path to extract
-     * @param bool   $overwrite
-     *
-     * @return string
+     * The absolute file path to extract should be passed in the first argument.
      */
-    public static function extractFile($filePath, $overwrite = false)
+    public static function extractFile(string $filePath, bool $overwrite = false): string
     {
         $pharPath = \Phar::running(false);
 

--- a/tests/Notifier/AppleScriptNotifierTest.php
+++ b/tests/Notifier/AppleScriptNotifierTest.php
@@ -18,6 +18,7 @@ use Joli\JoliNotif\Util\OsHelper;
 class AppleScriptNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
+
     const BINARY = 'osascript';
 
     public function testIsSupported()
@@ -45,7 +46,7 @@ class AppleScriptNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_LOW, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new AppleScriptNotifier();
     }
@@ -53,7 +54,7 @@ class AppleScriptNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body"'
@@ -63,7 +64,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body" with title "I'\''m the notification title"'
@@ -73,7 +74,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithASubtitle()
+    protected function getExpectedCommandLineForNotificationWithASubtitle(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body" subtitle "I'\''m the notification subtitle"'
@@ -83,7 +84,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithASound()
+    protected function getExpectedCommandLineForNotificationWithASound(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body" sound name "Frog"'
@@ -93,7 +94,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body"'
@@ -103,7 +104,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         return <<<CLI
 'osascript' '-e' 'display notification "I'\''m the notification body" with title "I'\''m the notification title" subtitle "I'\''m the notification subtitle" sound name "Frog"'

--- a/tests/Notifier/CliBasedNotifierTestTrait.php
+++ b/tests/Notifier/CliBasedNotifierTestTrait.php
@@ -13,7 +13,7 @@ namespace Joli\JoliNotif\tests\Notifier;
 
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Util\OsHelper;
-use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Process\Process;
 
 /**
  * Classes using this trait should define a BINARY constant and extend
@@ -36,29 +36,20 @@ trait CliBasedNotifierTestTrait
     }
 
     /**
-     * @param Notification $notification
-     * @param string       $expectedCommandLine
-     *
      * @dataProvider provideValidNotifications
      */
-    public function testConfigureProcessAcceptAnyValidNotification(Notification $notification, $expectedCommandLine)
+    public function testConfigureProcessAcceptAnyValidNotification(Notification $notification, string $expectedCommandLine)
     {
         try {
-            $processBuilder = new ProcessBuilder();
-            $processBuilder->setPrefix(self::BINARY);
+            $arguments = $this->invokeMethod($this->getNotifier(), 'getCommandLineArguments', [$notification]);
 
-            $this->invokeMethod($this->getNotifier(), 'configureProcess', [$processBuilder, $notification]);
-
-            $this->assertSame($expectedCommandLine, $processBuilder->getProcess()->getCommandLine());
+            $this->assertSame($expectedCommandLine, (new Process(array_merge([self::BINARY], $arguments)))->getCommandLine());
         } catch (\Exception $e) {
             $this->fail($e->getMessage());
         }
     }
 
-    /**
-     * @return array
-     */
-    public function provideValidNotifications()
+    public function provideValidNotifications(): array
     {
         $iconDir = $this->getIconDir();
 
@@ -140,58 +131,40 @@ trait CliBasedNotifierTestTrait
         }
     }
 
-    public function getIconDir()
+    public function getIconDir(): string
     {
         return realpath(dirname(__DIR__).'/fixtures');
     }
 
-    /**
-     * @return string
-     */
-    abstract protected function getExpectedCommandLineForNotification();
+    abstract protected function getExpectedCommandLineForNotification(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getExpectedCommandLineForNotificationWithATitle();
+    abstract protected function getExpectedCommandLineForNotificationWithATitle(): string;
 
     /**
      * Subtitle is supported only on few notifier.
-     *
-     * @return string
      */
-    protected function getExpectedCommandLineForNotificationWithASubtitle()
+    protected function getExpectedCommandLineForNotificationWithASubtitle(): string
     {
         return $this->getExpectedCommandLineForNotification();
     }
 
     /**
      * Sound is supported only on few notifier.
-     *
-     * @return string
      */
-    protected function getExpectedCommandLineForNotificationWithASound()
+    protected function getExpectedCommandLineForNotificationWithASound(): string
     {
         return $this->getExpectedCommandLineForNotification();
     }
 
     /**
      * Sound is supported only on few notifier.
-     *
-     * @return string
      */
-    protected function getExpectedCommandLineForNotificationWithAnUrl()
+    protected function getExpectedCommandLineForNotificationWithAnUrl(): string
     {
         return $this->getExpectedCommandLineForNotification();
     }
 
-    /**
-     * @return string
-     */
-    abstract protected function getExpectedCommandLineForNotificationWithAnIcon();
+    abstract protected function getExpectedCommandLineForNotificationWithAnIcon(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getExpectedCommandLineForNotificationWithAllOptions();
+    abstract protected function getExpectedCommandLineForNotificationWithAllOptions(): string;
 }

--- a/tests/Notifier/GrowlNotifyNotifierTest.php
+++ b/tests/Notifier/GrowlNotifyNotifierTest.php
@@ -17,6 +17,7 @@ use Joli\JoliNotif\Notifier\GrowlNotifyNotifier;
 class GrowlNotifyNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
+
     const BINARY = 'growlnotify';
 
     public function testGetBinary()
@@ -33,7 +34,7 @@ class GrowlNotifyNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_HIGH, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new GrowlNotifyNotifier();
     }
@@ -41,7 +42,7 @@ class GrowlNotifyNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<CLI
 'growlnotify' '--message' 'I'\''m the notification body'
@@ -51,7 +52,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'growlnotify' '--message' 'I'\''m the notification body' '--title' 'I'\''m the notification title'
@@ -61,7 +62,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         $iconDir = $this->getIconDir();
 
@@ -73,7 +74,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         $iconDir = $this->getIconDir();
 

--- a/tests/Notifier/NotifierTestCase.php
+++ b/tests/Notifier/NotifierTestCase.php
@@ -16,10 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class NotifierTestCase extends TestCase
 {
-    /**
-     * @return Notifier
-     */
-    abstract protected function getNotifier();
+    abstract protected function getNotifier(): Notifier;
 
     /**
      * Call protected/private method of a class.
@@ -30,7 +27,7 @@ abstract class NotifierTestCase extends TestCase
      *
      * @return mixed method return
      */
-    protected function invokeMethod($object, $methodName, array $parameters = [])
+    protected function invokeMethod($object, string $methodName, array $parameters = [])
     {
         $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);

--- a/tests/Notifier/NotifuNotifierTest.php
+++ b/tests/Notifier/NotifuNotifierTest.php
@@ -18,6 +18,7 @@ class NotifuNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
     use BinaryProviderTestTrait;
+
     const BINARY = 'notifu';
 
     public function testGetBinary()
@@ -34,7 +35,7 @@ class NotifuNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_LOW, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new NotifuNotifier();
     }
@@ -42,7 +43,7 @@ class NotifuNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<CLI
 'notifu' '/m' 'I'\''m the notification body'
@@ -52,7 +53,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'notifu' '/m' 'I'\''m the notification body' '/p' 'I'\\''m the notification title'
@@ -62,7 +63,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         $iconDir = $this->getIconDir();
 
@@ -74,7 +75,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         $iconDir = $this->getIconDir();
 

--- a/tests/Notifier/NotifySendNotifierTest.php
+++ b/tests/Notifier/NotifySendNotifierTest.php
@@ -17,6 +17,7 @@ use Joli\JoliNotif\Notifier\NotifySendNotifier;
 class NotifySendNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
+
     const BINARY = 'notify-send';
 
     public function testGetBinary()
@@ -33,7 +34,7 @@ class NotifySendNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_MEDIUM, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new NotifySendNotifier();
     }
@@ -41,7 +42,7 @@ class NotifySendNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<CLI
 'notify-send' 'I'\''m the notification body'
@@ -51,7 +52,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'notify-send' 'I'\''m the notification title' 'I'\''m the notification body'
@@ -61,7 +62,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         $iconDir = $this->getIconDir();
 
@@ -73,7 +74,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         $iconDir = $this->getIconDir();
 

--- a/tests/Notifier/NullNotifierTest.php
+++ b/tests/Notifier/NullNotifierTest.php
@@ -39,7 +39,7 @@ class NullNotifierTest extends NotifierTestCase
         $this->assertFalse($notifier->send($notification));
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new NullNotifier();
     }

--- a/tests/Notifier/TerminalNotifierNotifierTest.php
+++ b/tests/Notifier/TerminalNotifierNotifierTest.php
@@ -18,6 +18,7 @@ use Joli\JoliNotif\Util\OsHelper;
 class TerminalNotifierNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
+
     const BINARY = 'terminal-notifier';
 
     public function testGetBinary()
@@ -34,7 +35,7 @@ class TerminalNotifierNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_MEDIUM, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new TerminalNotifierNotifier();
     }
@@ -42,7 +43,7 @@ class TerminalNotifierNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<CLI
 'terminal-notifier' '-message' 'I'\''m the notification body'
@@ -52,7 +53,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'terminal-notifier' '-message' 'I'\''m the notification body' '-title' 'I'\''m the notification title'
@@ -62,7 +63,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnUrl()
+    protected function getExpectedCommandLineForNotificationWithAnUrl(): string
     {
         return <<<CLI
 'terminal-notifier' '-message' 'I'\''m the notification body' '-open' 'https://google.com'
@@ -72,7 +73,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         if (OsHelper::isMacOS() && version_compare(OsHelper::getMacOSVersion(), '10.9.0', '>=')) {
             $iconDir = $this->getIconDir();
@@ -90,7 +91,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         if (OsHelper::isMacOS() && version_compare(OsHelper::getMacOSVersion(), '10.9.0', '>=')) {
             $iconDir = $this->getIconDir();

--- a/tests/Notifier/ToasterNotifierTest.php
+++ b/tests/Notifier/ToasterNotifierTest.php
@@ -18,6 +18,7 @@ class ToasterNotifierTest extends NotifierTestCase
 {
     use CliBasedNotifierTestTrait;
     use BinaryProviderTestTrait;
+
     const BINARY = 'toast';
 
     public function testGetBinary()
@@ -34,7 +35,7 @@ class ToasterNotifierTest extends NotifierTestCase
         $this->assertSame(Notifier::PRIORITY_MEDIUM, $notifier->getPriority());
     }
 
-    protected function getNotifier()
+    protected function getNotifier(): Notifier
     {
         return new ToasterNotifier();
     }
@@ -42,7 +43,7 @@ class ToasterNotifierTest extends NotifierTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotification()
+    protected function getExpectedCommandLineForNotification(): string
     {
         return <<<'CLI'
 'toast' '-m' 'I'\''m the notification body'
@@ -52,7 +53,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithATitle()
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
     {
         return <<<CLI
 'toast' '-m' 'I'\''m the notification body' '-t' 'I'\''m the notification title'
@@ -62,7 +63,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAnIcon()
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
     {
         $iconDir = $this->getIconDir();
 
@@ -74,7 +75,7 @@ CLI;
     /**
      * {@inheritdoc}
      */
-    protected function getExpectedCommandLineForNotificationWithAllOptions()
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
     {
         $iconDir = $this->getIconDir();
 

--- a/tests/NotifierFactoryTest.php
+++ b/tests/NotifierFactoryTest.php
@@ -161,7 +161,7 @@ class NotifierFactoryTest extends TestCase
         ]);
     }
 
-    private function assertNotifierClasses($expectedNotifierClasses, $notifiers)
+    private function assertNotifierClasses(array $expectedNotifierClasses, array $notifiers)
     {
         $expectedCount = count($expectedNotifierClasses);
         $this->assertSame($expectedCount, count($notifiers));

--- a/tests/Util/PharExtractorTest.php
+++ b/tests/Util/PharExtractorTest.php
@@ -85,10 +85,7 @@ class PharExtractorTest extends TestCase
         unlink($extractedFilePath);
     }
 
-    /**
-     * @return string
-     */
-    private function getTestDir()
+    private function getTestDir(): string
     {
         $testDir = sys_get_temp_dir().'/test-jolinotif';
 
@@ -99,13 +96,7 @@ class PharExtractorTest extends TestCase
         return $testDir;
     }
 
-    /**
-     * @param string $pharPath
-     * @param string $fileRelativePath
-     * @param string $fileContent
-     * @param bool   $overwrite
-     */
-    private function generatePhar($pharPath, $fileRelativePath, $fileContent, $overwrite)
+    private function generatePhar(string $pharPath, string $fileRelativePath, string $fileContent, bool $overwrite)
     {
         $rootPackage = dirname(dirname(__DIR__));
         $bootstrap = <<<'PHAR_BOOTSTRAP'

--- a/tests/fixtures/ConfigurableNotifier.php
+++ b/tests/fixtures/ConfigurableNotifier.php
@@ -36,7 +36,7 @@ class ConfigurableNotifier implements Notifier
      * @param $priority
      * @param $sendReturn
      */
-    public function __construct($supported, $priority = Notifier::PRIORITY_MEDIUM, $sendReturn = true)
+    public function __construct(bool $supported, int $priority = Notifier::PRIORITY_MEDIUM, bool $sendReturn = true)
     {
         $this->supported = $supported;
         $this->priority = $priority;
@@ -46,7 +46,7 @@ class ConfigurableNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function isSupported()
+    public function isSupported(): bool
     {
         return $this->supported;
     }
@@ -54,7 +54,7 @@ class ConfigurableNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return $this->priority;
     }
@@ -62,7 +62,7 @@ class ConfigurableNotifier implements Notifier
     /**
      * {@inheritdoc}
      */
-    public function send(Notification $notification)
+    public function send(Notification $notification): bool
     {
         return $this->sendReturn;
     }


### PR DESCRIPTION
Fix #49

Also drop support for Symfony < 3.3.
Drop support for PHP < 7 & HHVM.
Add typehint everywhere.
Better CI and tests configuration.