### PR TITLE
use .gitattributes file to limit zip payload size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+ * text=auto
+
+/doc export-ignore
+/example export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+CHANGELOG.md export-ignore
+VERSIONING.md export-ignore
+CONTRIBUTING.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
  * text=auto
 
 /doc export-ignore
-/example export-ignore
 /tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
This PR adds `export-ignore` capability via a `.gitattributes`. 

Basically this allows github to only send the relevant source files in the .zip/.tar.gz files when composer is installing them. Doing so limits the file size needed to transfer and keeps unnecessary development files (tests/docs/etc) out of production environments.

You can read more about .gitattributes [here](https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#_code_export_ignore_code)