### PR TITLE
Fixed Symfony 4 Process constructor deprecation

### DIFF
--- a/src/Util/OsHelper.php
+++ b/src/Util/OsHelper.php
@@ -75,7 +75,7 @@ class OsHelper
     public static function getMacOSVersion(): string
     {
         if (null === self::$macOSVersion) {
-            $process = new Process('sw_vers -productVersion');
+            $process = new Process(['sw_vers', '-productVersion']);
             $process->run();
             self::$macOSVersion = (string) trim($process->getOutput());
         }


### PR DESCRIPTION
> Passing a command as string when creating a "Symfony\Component\Process\Process" instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the "Process::fromShellCommandline()" constructor if you need features provided by the shell.

c.f issue #59 