### PR TITLE
KDialog notifier

### DIFF
--- a/doc/03-notifier.md
+++ b/doc/03-notifier.md
@@ -33,6 +33,16 @@ Here is the full list of supported notifiers, grouped by platform:
 
 ### Linux
 
+#### KDialogNotifier
+
+This notifier uses the executable `kdialog` (part of the standard KDE 5 Plasma
+Desktop installation) which should be installed by default on most Linux
+distributions which use the KDE 5 Plasma Desktop such as KUbuntu.
+
+kdialog can display notifications with a body and a title. It does not support
+icons. A default timeout of 5 seconds is hard-coded for the notification as it
+needs to be part of the command line.
+
 #### NotifySendNotifier
 
 This notifier uses the executable `notify-send` (available in the

--- a/src/Notifier/KDialogNotifier.php
+++ b/src/Notifier/KDialogNotifier.php
@@ -43,7 +43,7 @@ class KDialogNotifier extends CliBasedNotifier
         $arguments = [];
 
         if ($notification->getTitle()) {
-	        $arguments[] = '--title';
+            $arguments[] = '--title';
             $arguments[] = $notification->getTitle();
         }
 
@@ -51,7 +51,7 @@ class KDialogNotifier extends CliBasedNotifier
         $arguments[] = $notification->getBody();
 
         // Timeout, in seconds
-	    $arguments[] = 5;
+        $arguments[] = 5;
 
         return $arguments;
     }

--- a/src/Notifier/KDialogNotifier.php
+++ b/src/Notifier/KDialogNotifier.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the JoliNotif project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Joli\JoliNotif\Notifier;
+
+use Joli\JoliNotif\Notification;
+
+/**
+ * This notifier can be used on Linux distributions running KDE, using the command kdialog.
+ * This command is shipped by default with KDE.
+ */
+class KDialogNotifier extends CliBasedNotifier
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinary(): string
+    {
+        return 'kdialog';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return static::PRIORITY_HIGH;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCommandLineArguments(Notification $notification): array
+    {
+        $arguments = [];
+
+        if ($notification->getTitle()) {
+	        $arguments[] = '--title';
+            $arguments[] = $notification->getTitle();
+        }
+
+        $arguments[] = '--passivepopup';
+        $arguments[] = $notification->getBody();
+
+        // Timeout, in seconds
+	    $arguments[] = 5;
+
+        return $arguments;
+    }
+}

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -83,7 +83,7 @@ class NotifierFactory
             new GrowlNotifyNotifier(),
             new TerminalNotifierNotifier(),
             new AppleScriptNotifier(),
-	        new KDialogNotifier(),
+            new KDialogNotifier(),
             new NotifySendNotifier(),
         ];
     }

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -14,6 +14,7 @@ namespace Joli\JoliNotif;
 use Joli\JoliNotif\Exception\NoSupportedNotifierException;
 use Joli\JoliNotif\Notifier\AppleScriptNotifier;
 use Joli\JoliNotif\Notifier\GrowlNotifyNotifier;
+use Joli\JoliNotif\Notifier\KDialogNotifier;
 use Joli\JoliNotif\Notifier\NotifuNotifier;
 use Joli\JoliNotif\Notifier\NotifySendNotifier;
 use Joli\JoliNotif\Notifier\NullNotifier;
@@ -82,6 +83,7 @@ class NotifierFactory
             new GrowlNotifyNotifier(),
             new TerminalNotifierNotifier(),
             new AppleScriptNotifier(),
+	        new KDialogNotifier(),
             new NotifySendNotifier(),
         ];
     }

--- a/tests/Notifier/KDialogNotifierTest.php
+++ b/tests/Notifier/KDialogNotifierTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the JoliNotif project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Joli\JoliNotif\tests\Notifier;
+
+use Joli\JoliNotif\Notifier;
+use Joli\JoliNotif\Notifier\NotifySendNotifier;
+
+class KDialogNotifierTest extends NotifierTestCase
+{
+    use CliBasedNotifierTestTrait;
+
+    const BINARY = 'kdialog';
+
+    public function testGetBinary()
+    {
+        $notifier = $this->getNotifier();
+
+        $this->assertSame(self::BINARY, $notifier->getBinary());
+    }
+
+    public function testGetPriority()
+    {
+        $notifier = $this->getNotifier();
+
+        $this->assertSame(Notifier::PRIORITY_HIGH, $notifier->getPriority());
+    }
+
+    protected function getNotifier(): Notifier
+    {
+        return new Notifier\KDialogNotifier();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommandLineForNotification(): string
+    {
+        return <<<CLI
+'kdialog' '--passivepopup' 'I'\''m the notification body' '5'
+CLI;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommandLineForNotificationWithATitle(): string
+    {
+        return <<<CLI
+'kdialog' '--title' 'I'\''m the notification title' '--passivepopup' 'I'\''m the notification body' '5'
+CLI;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommandLineForNotificationWithAnIcon(): string
+    {
+        return <<<CLI
+'kdialog' '--passivepopup' 'I'\''m the notification body' '5'
+CLI;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExpectedCommandLineForNotificationWithAllOptions(): string
+    {
+        return <<<CLI
+'kdialog' '--title' 'I'\''m the notification title' '--passivepopup' 'I'\''m the notification body' '5'
+CLI;
+    }
+}

--- a/tests/Notifier/KDialogNotifierTest.php
+++ b/tests/Notifier/KDialogNotifierTest.php
@@ -12,7 +12,6 @@
 namespace Joli\JoliNotif\tests\Notifier;
 
 use Joli\JoliNotif\Notifier;
-use Joli\JoliNotif\Notifier\NotifySendNotifier;
 
 class KDialogNotifierTest extends NotifierTestCase
 {

--- a/tests/NotifierFactoryTest.php
+++ b/tests/NotifierFactoryTest.php
@@ -29,6 +29,7 @@ class NotifierFactoryTest extends TestCase
                 'Joli\\JoliNotif\\Notifier\\GrowlNotifyNotifier',
                 'Joli\\JoliNotif\\Notifier\\TerminalNotifierNotifier',
                 'Joli\\JoliNotif\\Notifier\\AppleScriptNotifier',
+                'Joli\\JoliNotif\\Notifier\\KDialogNotifier',
                 'Joli\\JoliNotif\\Notifier\\NotifySendNotifier',
             ];
         } else {
@@ -56,6 +57,7 @@ class NotifierFactoryTest extends TestCase
                 'Joli\\JoliNotif\\Notifier\\GrowlNotifyNotifier',
                 'Joli\\JoliNotif\\Notifier\\TerminalNotifierNotifier',
                 'Joli\\JoliNotif\\Notifier\\AppleScriptNotifier',
+                'Joli\\JoliNotif\\Notifier\\KDialogNotifier',
                 'Joli\\JoliNotif\\Notifier\\NotifySendNotifier',
             ];
         } else {


### PR DESCRIPTION
This PR adds support for the `kdialog` executable on Linux distributions which use the KDE 5 Plasma Desktop, e.g. Kubuntu.

KDialog is preinstalled in these distributions whereas notify-send is not. Therefore I chose to give it a higher priority than notify-send. This also addresses the frustration of trying to use JoliNotif without _properly_ reading the documentation first, like yours truly did.

This has been tested on Kubuntu 20.04 but as far as I can tell the kdialog binary has been available for several years, throughout the KDE 5 life span.

I will be happy to provide any additional information should it be necessary.