### PR TITLE
Using assertDirectoryExists assertion instead

### DIFF
--- a/tests/Notifier/BinaryProviderTestTrait.php
+++ b/tests/Notifier/BinaryProviderTestTrait.php
@@ -20,7 +20,7 @@ trait BinaryProviderTestTrait
     {
         $notifier = $this->getNotifier();
 
-        $this->assertTrue(is_dir($notifier->getRootDir()));
+        $this->assertDirectoryExists($notifier->getRootDir());
     }
 
     public function testEmbeddedBinaryExists()


### PR DESCRIPTION
# Changed log
- Using the `assertDirectoryExists` assertion instead.