### PR TITLE
Deprecate OsHelper in favor of jolicode/php-os-helper

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['8.1', '8.2']
+                php-version: ['8.2', '8.3']
                 composer-flags: ['']
                 name: ['']
                 include:
-                    - php-version: 8.0
+                    - php-version: 8.1
                       composer-flags: '--prefer-lowest'
                       name: '(prefer lowest dependencies)'
         steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Not yet released
 
 * Deprecated Joli\JoliNotif\Util\OsHelper in favor of jolicode/php-os-helper package
+* Added support for Symfony 7.x
+* Added support for PHP 8.3
+* Dropped support for PHP 8.0
 
 ## 2.5.2 (2023-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes between versions
 
+## Not yet released
+
+* Deprecated Joli\JoliNotif\Util\OsHelper in favor of jolicode/php-os-helper package
+
 ## 2.5.2 (2023-05-24)
 
 * Added PHAR to GitHub releases

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require": {
         "php": ">=8.0",
+        "jolicode/php-os-helper": "^0.1.0",
         "symfony/process": "^5.4 || ^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         }
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "jolicode/php-os-helper": "^0.1.0",
-        "symfony/process": "^5.4 || ^6.0"
+        "symfony/process": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
-        "symfony/finder": "^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0"
+        "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0"
     },
     "bin": [
         "jolinotif"

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -11,6 +11,4 @@
 
 namespace Joli\JoliNotif\Exception;
 
-interface Exception
-{
-}
+interface Exception {}

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -11,8 +11,8 @@
 
 namespace Joli\JoliNotif;
 
-use Joli\JoliNotif\Util\OsHelper;
 use Joli\JoliNotif\Util\PharExtractor;
+use JoliCode\PhpOsHelper\OsHelper;
 
 class Notification
 {

--- a/src/Notifier/AppleScriptNotifier.php
+++ b/src/Notifier/AppleScriptNotifier.php
@@ -12,7 +12,7 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 
 /**
  * This notifier can be used on Mac OS X 10.9+.

--- a/src/Notifier/CliBasedNotifier.php
+++ b/src/Notifier/CliBasedNotifier.php
@@ -14,8 +14,8 @@ namespace Joli\JoliNotif\Notifier;
 use Joli\JoliNotif\Exception\InvalidNotificationException;
 use Joli\JoliNotif\Notification;
 use Joli\JoliNotif\Notifier;
-use Joli\JoliNotif\Util\OsHelper;
 use Joli\JoliNotif\Util\PharExtractor;
+use JoliCode\PhpOsHelper\OsHelper;
 use Symfony\Component\Process\Process;
 
 abstract class CliBasedNotifier implements Notifier

--- a/src/Notifier/NotifuNotifier.php
+++ b/src/Notifier/NotifuNotifier.php
@@ -12,7 +12,7 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 
 /**
  * This notifier can be used on Windows Seven and provides its own binaries if

--- a/src/Notifier/SnoreToastNotifier.php
+++ b/src/Notifier/SnoreToastNotifier.php
@@ -12,7 +12,7 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 use Symfony\Component\Process\Process;
 
 /**

--- a/src/Notifier/TerminalNotifierNotifier.php
+++ b/src/Notifier/TerminalNotifierNotifier.php
@@ -12,7 +12,7 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 
 /**
  * This notifier can be used on Mac OS X 10.8, or higher, using the

--- a/src/Notifier/ToasterNotifier.php
+++ b/src/Notifier/ToasterNotifier.php
@@ -12,7 +12,7 @@
 namespace Joli\JoliNotif\Notifier;
 
 use Joli\JoliNotif\Notification;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 
 /**
  * This notifier can be used on Windows Eight and higher and provides its own

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -20,7 +20,7 @@ use Joli\JoliNotif\Notifier\NotifySendNotifier;
 use Joli\JoliNotif\Notifier\NullNotifier;
 use Joli\JoliNotif\Notifier\SnoreToastNotifier;
 use Joli\JoliNotif\Notifier\TerminalNotifierNotifier;
-use Joli\JoliNotif\Util\OsHelper;
+use JoliCode\PhpOsHelper\OsHelper;
 
 class NotifierFactory
 {

--- a/src/Util/OsHelper.php
+++ b/src/Util/OsHelper.php
@@ -11,64 +11,9 @@
 
 namespace Joli\JoliNotif\Util;
 
-use Symfony\Component\Process\Process;
+use JoliCode\PhpOsHelper\OsHelper as BaseOsHelper;
 
-class OsHelper
-{
-    private static string $kernelName;
-    private static string $kernelVersion;
-    private static string $macOSVersion;
-
-    public static function isUnix(): bool
-    {
-        return '/' === \DIRECTORY_SEPARATOR;
-    }
-
-    public static function isWindowsSubsystemForLinux(): bool
-    {
-        return self::isUnix() && false !== mb_strpos(strtolower(php_uname()), 'microsoft');
-    }
-
-    public static function isWindows(): bool
-    {
-        return '\\' === \DIRECTORY_SEPARATOR;
-    }
-
-    public static function isWindowsSeven(): bool
-    {
-        if (!isset(self::$kernelVersion)) {
-            self::$kernelVersion = php_uname('r');
-        }
-
-        return '6.1' === self::$kernelVersion;
-    }
-
-    public static function isWindowsEightOrHigher(): bool
-    {
-        if (!isset(self::$kernelVersion)) {
-            self::$kernelVersion = php_uname('r');
-        }
-
-        return version_compare(self::$kernelVersion, '6.2', '>=');
-    }
-
-    public static function isMacOS(): bool
-    {
-        if (!isset(self::$kernelName)) {
-            self::$kernelName = php_uname('s');
-        }
-
-        return str_contains(self::$kernelName, 'Darwin');
-    }
-
-    public static function getMacOSVersion(): string
-    {
-        if (!isset(self::$macOSVersion)) {
-            $process = new Process(['sw_vers', '-productVersion']);
-            $process->run();
-            self::$macOSVersion = trim($process->getOutput());
-        }
-
-        return self::$macOSVersion;
-    }
-}
+/**
+ * @deprecated since 2.6, use OsHelper from jolicode/php-os-helper instead
+ */
+class OsHelper extends BaseOsHelper {}


### PR DESCRIPTION
Also add support for sf 7 and PHP 8.3 and drop support for PHP 8.0