### PR TITLE
add -contentImage option to TerminalNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released yet
 
 * Added wsl-notify-send notifier for Windows Subsystem for Linux
+* Changed TerminalNotifier to use contentImage option for icon instead of appIcon
 
 ## 2.6.0 (2023-12-03)
 

--- a/src/Notifier/TerminalNotifierNotifier.php
+++ b/src/Notifier/TerminalNotifierNotifier.php
@@ -47,6 +47,11 @@ class TerminalNotifierNotifier extends CliBasedNotifier
             $arguments[] = $notification->getIcon();
         }
 
+        if ($notification->getOption('contentImage')) {
+            $arguments[] = '-contentImage';
+            $arguments[] = $notification->getOption('contentImage');
+        }        
+
         if ($notification->getOption('url')) {
             $arguments[] = '-open';
             $arguments[] = $notification->getOption('url');

--- a/src/Notifier/TerminalNotifierNotifier.php
+++ b/src/Notifier/TerminalNotifierNotifier.php
@@ -43,14 +43,9 @@ class TerminalNotifierNotifier extends CliBasedNotifier
         }
 
         if ($notification->getIcon() && version_compare(OsHelper::getMacOSVersion(), '10.9.0', '>=')) {
-            $arguments[] = '-appIcon';
+            $arguments[] = '-contentImage';
             $arguments[] = $notification->getIcon();
         }
-
-        if ($notification->getOption('contentImage')) {
-            $arguments[] = '-contentImage';
-            $arguments[] = $notification->getOption('contentImage');
-        }        
 
         if ($notification->getOption('url')) {
             $arguments[] = '-open';

--- a/tests/Notifier/TerminalNotifierNotifierTest.php
+++ b/tests/Notifier/TerminalNotifierNotifierTest.php
@@ -67,7 +67,7 @@ class TerminalNotifierNotifierTest extends NotifierTestCase
             $iconDir = $this->getIconDir();
 
             return <<<CLI
-                'terminal-notifier' '-message' 'I'\\''m the notification body' '-appIcon' '{$iconDir}/image.gif'
+                'terminal-notifier' '-message' 'I'\\''m the notification body' '-contentImage' '{$iconDir}/image.gif'
                 CLI;
         }
 
@@ -82,7 +82,7 @@ class TerminalNotifierNotifierTest extends NotifierTestCase
             $iconDir = $this->getIconDir();
 
             return <<<CLI
-                'terminal-notifier' '-message' 'I'\\''m the notification body' '-title' 'I'\\''m the notification title' '-appIcon' '{$iconDir}/image.gif' '-open' 'https://google.com'
+                'terminal-notifier' '-message' 'I'\\''m the notification body' '-title' 'I'\\''m the notification title' '-contentImage' '{$iconDir}/image.gif' '-open' 'https://google.com'
                 CLI;
         }
 


### PR DESCRIPTION
Related to https://github.com/jolicode/JoliNotif/issues/73

Since appIcon is no longer supported, there is this alternative to including an image using -contentImage and this PR adds the ability to set the appImage as an option.