### PR TITLE
New notifer for Linux which use libnotify and PHP-FFI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  extensions: mbstring, xml
+                  extensions: mbstring, xml, ffi
                   ini-values: phar.readonly="Off"
 
             - name: Get composer cache directory
@@ -70,6 +70,10 @@ jobs:
             - name: Install Composer dependencies
               run: |
                   composer update --prefer-dist --no-interaction ${{ matrix.composer-flags }}
+
+            - name: Install libnotify4 for LibNotifyNotifier
+              run: |
+                sudo apt-get install -y --no-install-recommends --no-install-suggests libnotify4
 
             - name: Run Tests
               run: php vendor/bin/simple-phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released yet
 
 * Added wsl-notify-send notifier for Windows Subsystem for Linux
+* Added libnotify based notifier for Linux through FFI
 * Changed TerminalNotifier to use contentImage option for icon instead of appIcon
 * Fixed phar missing some dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0"
     },
+    "suggest": {
+        "ext-ffi": "Needed to send notifications via libnotify"
+    },
     "bin": [
         "jolinotif"
     ],

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
-        "ext-ffi": "Needed to send notifications via libnotify"
+        "ext-ffi": "Needed to send notifications via libnotify on Linux"
     },
     "bin": [
         "jolinotif"

--- a/doc/03-notifier.md
+++ b/doc/03-notifier.md
@@ -51,6 +51,13 @@ distributions.
 
 notify-send can display notification with a body, a title and an icon.
 
+##### LibNotifyNotifier
+
+This notifier use the FFI PHP extension. 
+The C library `libnotify` should be installed by default on most Linux distributions wih graphical interface.
+
+LibNotifyNotifier can display notification with a body, a title and an icon.
+
 ### Mac OS
 
 #### GrowlNotifyNotifier

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,5 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
     excludePaths:
         analyse: []
+    ignoreErrors:
+        - '#Call to an undefined method FFI::.+#'

--- a/src/Exception/FFIRuntimeException.php
+++ b/src/Exception/FFIRuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the JoliNotif project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Joli\JoliNotif\Exception;
+
+class FFIRuntimeException extends \RuntimeException implements Exception
+{
+}

--- a/src/Notifier/FFI/ffi-libnotify.h
+++ b/src/Notifier/FFI/ffi-libnotify.h
@@ -1,0 +1,79 @@
+#define FFI_LIB "libnotify.so.4"
+
+typedef signed short gint16;
+typedef int gint;
+typedef bool gboolean;
+typedef void* gpointer;
+typedef unsigned int gsize;
+typedef unsigned int guint;
+typedef unsigned long gulong;
+typedef gulong GType;
+
+typedef struct _GTypeClass GTypeClass;
+typedef struct _GSList GSList;
+typedef struct _GTypeInstance GTypeInstance;
+typedef struct _GObject GObject;
+typedef struct _GObjectClass GObjectClass;
+typedef struct _GObject GInitiallyUnowned;
+typedef struct _GObjectClass GInitiallyUnownedClass;
+typedef struct _GObjectConstructParam GObjectConstructParam;
+
+typedef struct _NotifyNotification NotifyNotification;
+typedef struct _NotifyNotificationClass NotifyNotificationClass;
+typedef struct _NotifyNotificationPrivate NotifyNotificationPrivate;
+
+typedef struct _GTypeInstanceError GError;
+
+struct _GSList
+{
+  gpointer data;
+  GSList *next;
+};
+
+struct _GTypeClass {
+    GType g_type;
+};
+
+struct  _GObjectClass
+{
+  GTypeClass   g_type_class;
+  GSList      *construct_properties;
+  gsize   flags;
+  gpointer  pdummy[6];
+};
+
+struct _GTypeInstance {
+    GTypeClass *g_class;
+};
+
+struct  _GObject
+{
+  GTypeInstance  g_type_instance;
+  guint ref_count;
+  // GData *qdata;
+};
+
+struct _NotifyNotification
+{
+        /*< private >*/
+        GObject                    parent_object;
+
+        NotifyNotificationPrivate *priv;
+};
+
+struct _NotifyNotificationClass
+{
+        GObjectClass    parent_class;
+
+        /* Signals */
+        void            (*closed) (NotifyNotification *notification);
+};
+
+
+gboolean notify_init(const char *app_name);
+gboolean notify_is_initted (void);
+void notify_uninit (void);
+const char* notify_get_app_name ( void );
+NotifyNotification *notify_notification_new(const char *summary, const char *body, const char *icon);
+gboolean notify_notification_show (NotifyNotification *notification, GError **error);
+void g_object_unref (gpointer object);

--- a/src/Notifier/FFI/ffi-libnotify.h
+++ b/src/Notifier/FFI/ffi-libnotify.h
@@ -1,79 +1,13 @@
 #define FFI_LIB "libnotify.so.4"
 
-typedef signed short gint16;
-typedef int gint;
 typedef bool gboolean;
 typedef void* gpointer;
-typedef unsigned int gsize;
-typedef unsigned int guint;
-typedef unsigned long gulong;
-typedef gulong GType;
-
-typedef struct _GTypeClass GTypeClass;
-typedef struct _GSList GSList;
-typedef struct _GTypeInstance GTypeInstance;
-typedef struct _GObject GObject;
-typedef struct _GObjectClass GObjectClass;
-typedef struct _GObject GInitiallyUnowned;
-typedef struct _GObjectClass GInitiallyUnownedClass;
-typedef struct _GObjectConstructParam GObjectConstructParam;
-
 typedef struct _NotifyNotification NotifyNotification;
-typedef struct _NotifyNotificationClass NotifyNotificationClass;
-typedef struct _NotifyNotificationPrivate NotifyNotificationPrivate;
-
 typedef struct _GTypeInstanceError GError;
-
-struct _GSList
-{
-  gpointer data;
-  GSList *next;
-};
-
-struct _GTypeClass {
-    GType g_type;
-};
-
-struct  _GObjectClass
-{
-  GTypeClass   g_type_class;
-  GSList      *construct_properties;
-  gsize   flags;
-  gpointer  pdummy[6];
-};
-
-struct _GTypeInstance {
-    GTypeClass *g_class;
-};
-
-struct  _GObject
-{
-  GTypeInstance  g_type_instance;
-  guint ref_count;
-  // GData *qdata;
-};
-
-struct _NotifyNotification
-{
-        /*< private >*/
-        GObject                    parent_object;
-
-        NotifyNotificationPrivate *priv;
-};
-
-struct _NotifyNotificationClass
-{
-        GObjectClass    parent_class;
-
-        /* Signals */
-        void            (*closed) (NotifyNotification *notification);
-};
-
 
 gboolean notify_init(const char *app_name);
 gboolean notify_is_initted (void);
 void notify_uninit (void);
-const char* notify_get_app_name ( void );
 NotifyNotification *notify_notification_new(const char *summary, const char *body, const char *icon);
 gboolean notify_notification_show (NotifyNotification *notification, GError **error);
 void g_object_unref (gpointer object);

--- a/src/Notifier/LibNotifyNotifier.php
+++ b/src/Notifier/LibNotifyNotifier.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the JoliNotif project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Joli\JoliNotif\Notifier;
+
+use Joli\JoliNotif\Exception\FFIRuntimeException;
+use Joli\JoliNotif\Exception\InvalidNotificationException;
+use Joli\JoliNotif\Notification;
+use Joli\JoliNotif\Notifier;
+use JoliCode\PhpOsHelper\OsHelper;
+
+class LibNotifyNotifier implements Notifier
+{
+    private static string $APP_NAME = 'jolinotif';
+
+    private ?\FFI $ffi;
+
+    public function __destruct()
+    {
+        if (isset($this->ffi) && null !== $this->ffi) {
+            $this->ffi->notify_uninit();
+        }
+    }
+
+    public static function isLibraryExists(): bool
+    {
+        return file_exists('/lib64/libnotify.so.4')
+            || file_exists('/lib/x86_64-linux-gnu/libnotify.so.4');
+    }
+
+    public function isSupported(): bool
+    {
+        return OsHelper::isUnix()
+            && !OsHelper::isMacOS()
+            && class_exists(\FFI::class)
+            && self::isLibraryExists();
+    }
+
+    public function getPriority(): int
+    {
+        return static::PRIORITY_HIGH;
+    }
+
+    public function send(Notification $notification): bool
+    {
+        if (!$notification->getBody()) {
+            throw new InvalidNotificationException($notification, 'Notification body can not be empty');
+        }
+
+        $this->initialize();
+        $notification = $this->ffi->notify_notification_new(
+            $notification->getTitle() ?? '',
+            $notification->getBody(),
+            $notification->getIcon()
+        );
+        $value = $this->ffi->notify_notification_show($notification, null);
+        $this->ffi->g_object_unref($notification);
+
+        return $value;
+    }
+
+    private function initialize(): void
+    {
+        if (isset($this->ffi)) {
+            return;
+        }
+
+        $this->ffi = \FFI::load(__DIR__ . '/FFI/ffi-libnotify.h');
+        if (!$this->ffi->notify_init(self::$APP_NAME)) {
+            throw new FFIRuntimeException('Unable to initialize libnotify');
+        }
+
+        if (!$this->ffi->notify_is_initted()) {
+            throw new FFIRuntimeException('Libnotify has not been initialized');
+        }
+    }
+}

--- a/src/Notifier/LibNotifyNotifier.php
+++ b/src/Notifier/LibNotifyNotifier.php
@@ -21,11 +21,11 @@ class LibNotifyNotifier implements Notifier
 {
     private static string $APP_NAME = 'jolinotif';
 
-    private ?\FFI $ffi;
+    private \FFI $ffi;
 
     public function __destruct()
     {
-        if (isset($this->ffi) && null !== $this->ffi) {
+        if (isset($this->ffi)) {
             $this->ffi->notify_uninit();
         }
     }
@@ -73,7 +73,14 @@ class LibNotifyNotifier implements Notifier
             return;
         }
 
-        $this->ffi = \FFI::load(__DIR__ . '/FFI/ffi-libnotify.h');
+        $ffi = \FFI::load(__DIR__ . '/FFI/ffi-libnotify.h');
+
+        if (!$ffi) {
+            throw new FFIRuntimeException('Unable to load libnotify');
+        }
+
+        $this->ffi = $ffi;
+
         if (!$this->ffi->notify_init(self::$APP_NAME)) {
             throw new FFIRuntimeException('Unable to initialize libnotify');
         }

--- a/src/NotifierFactory.php
+++ b/src/NotifierFactory.php
@@ -15,6 +15,7 @@ use Joli\JoliNotif\Exception\NoSupportedNotifierException;
 use Joli\JoliNotif\Notifier\AppleScriptNotifier;
 use Joli\JoliNotif\Notifier\GrowlNotifyNotifier;
 use Joli\JoliNotif\Notifier\KDialogNotifier;
+use Joli\JoliNotif\Notifier\LibNotifyNotifier;
 use Joli\JoliNotif\Notifier\NotifuNotifier;
 use Joli\JoliNotif\Notifier\NotifySendNotifier;
 use Joli\JoliNotif\Notifier\NullNotifier;
@@ -75,6 +76,7 @@ class NotifierFactory
     private static function getUnixNotifiers(): array
     {
         return [
+            new LibNotifyNotifier(),
             new GrowlNotifyNotifier(),
             new TerminalNotifierNotifier(),
             new AppleScriptNotifier(),

--- a/tests/Notifier/CliBasedNotifierTestTrait.php
+++ b/tests/Notifier/CliBasedNotifierTestTrait.php
@@ -131,11 +131,6 @@ trait CliBasedNotifierTestTrait
         }
     }
 
-    public function getIconDir(): string
-    {
-        return realpath(\dirname(__DIR__) . '/fixtures');
-    }
-
     abstract protected function getExpectedCommandLineForNotification(): string;
 
     abstract protected function getExpectedCommandLineForNotificationWithATitle(): string;

--- a/tests/Notifier/LibNotifyNotifierTest.php
+++ b/tests/Notifier/LibNotifyNotifierTest.php
@@ -35,7 +35,7 @@ class LibNotifyNotifierTest extends NotifierTestCase
     }
 
     /**
-     * @requires ffi
+     * @requires extension ffi
      */
     public function testInitialize()
     {
@@ -77,6 +77,9 @@ class LibNotifyNotifierTest extends NotifierTestCase
         }
     }
 
+    /**
+     * @requires extension ffi
+     */
     public function testSendNotificationWithAllOptions()
     {
         $notifier = $this->getNotifier();

--- a/tests/Notifier/LibNotifyNotifierTest.php
+++ b/tests/Notifier/LibNotifyNotifierTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the JoliNotif project.
+ *
+ * (c) Loïck Piera <pyrech@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Joli\JoliNotif\tests\Notifier;
+
+use Joli\JoliNotif\Exception\InvalidNotificationException;
+use Joli\JoliNotif\Notification;
+use Joli\JoliNotif\Notifier;
+use Joli\JoliNotif\Notifier\LibNotifyNotifier;
+use PHPUnit\Framework\TestCase;
+
+class LibNotifyNotifierTest extends TestCase
+{
+    public function testGetPriority()
+    {
+        $notifier = $this->getNotifier();
+
+        $this->assertSame(Notifier::PRIORITY_HIGH, $notifier->getPriority());
+    }
+
+    public function testSendWithEmptyBody()
+    {
+        $notifier = $this->getNotifier();
+
+        $this->expectException(InvalidNotificationException::class);
+        $this->expectExceptionMessage('Notification body can not be empty');
+        $notifier->send(new Notification());
+    }
+
+    /**
+     * @requires ffi
+     */
+    public function testInitialize()
+    {
+        $notifier = $this->getNotifier();
+
+        if (!$notifier::isLibraryExists()) {
+            $this->markTestSkipped('Looks like libnotify is not installed');
+        }
+
+        $closureToInitialize = \Closure::bind(static function (LibNotifyNotifier $notifier) {
+            $notifier->initialize();
+        }, null, LibNotifyNotifier::class);
+
+        $this->assertTrue($notifier->isSupported());
+        $closureToInitialize($notifier);
+    }
+
+    protected function getNotifier(): LibNotifyNotifier
+    {
+        return new LibNotifyNotifier();
+    }
+}

--- a/tests/Notifier/NotifierTestCase.php
+++ b/tests/Notifier/NotifierTestCase.php
@@ -18,6 +18,11 @@ abstract class NotifierTestCase extends TestCase
 {
     abstract protected function getNotifier(): Notifier;
 
+    protected function getIconDir(): string
+    {
+        return realpath(\dirname(__DIR__) . '/fixtures');
+    }
+
     /**
      * Call protected/private method of a class.
      *

--- a/tests/NotifierFactoryTest.php
+++ b/tests/NotifierFactoryTest.php
@@ -15,6 +15,7 @@ use Joli\JoliNotif\Exception\NoSupportedNotifierException;
 use Joli\JoliNotif\Notifier\AppleScriptNotifier;
 use Joli\JoliNotif\Notifier\GrowlNotifyNotifier;
 use Joli\JoliNotif\Notifier\KDialogNotifier;
+use Joli\JoliNotif\Notifier\LibNotifyNotifier;
 use Joli\JoliNotif\Notifier\NotifuNotifier;
 use Joli\JoliNotif\Notifier\NotifySendNotifier;
 use Joli\JoliNotif\Notifier\NullNotifier;
@@ -34,6 +35,7 @@ class NotifierFactoryTest extends TestCase
 
         if (OsHelper::isUnix()) {
             $expectedNotifierClasses = [
+                LibNotifyNotifier::class,
                 GrowlNotifyNotifier::class,
                 TerminalNotifierNotifier::class,
                 AppleScriptNotifier::class,
@@ -63,6 +65,7 @@ class NotifierFactoryTest extends TestCase
 
         if (OsHelper::isUnix()) {
             $expectedNotifierClasses = [
+                LibNotifyNotifier::class,
                 GrowlNotifyNotifier::class,
                 TerminalNotifierNotifier::class,
                 AppleScriptNotifier::class,


### PR DESCRIPTION
Hello

This PR add another notifier, which use FFI and libnotify.
Probably most of Linux notifier supported in this repository under the hood use this library.

This notifier has some advantages and disadvantages.
Support for FFI in PHP vary between distributions. Sometimes we need to install dedicated package.
In other hand can be slightly faster (we don't need to crate external process)
and more portable (we don't need external application, only libnotify).

FFI allows us to call C code from PHP script. 
The FFI extension need to be installed to use this notifier. 
Also support for FFI is only in CLI SAPI, due to security concerns.
 
At the moment I tested this notifier with:
* Ubuntu 20
* Ubuntu 22
* Ubuntu 24
* Fedora 39
* OpenSUSE Tumbleweed

**All existing notifiers use external commands and maybe this new notifier does not meet project goals.**
I decided to mark this PR as draft.
I can finish this PR if that notifier can be included in this package, otherwise you can close this PR.
