### PR TITLE
Add AbstractCliBasedDriver::launchProcess()

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -32,4 +32,4 @@ $result = $notifier->send($notification);
 
 $driver = $notifier->getDriver();
 
-echo 'Notification ', $result ? 'successfully sent' : 'failed', ' with ', str_replace('Joli\\JoliNotif\\Driver\\', '', $driver::class), \PHP_EOL;
+echo 'Notification ', $result ? 'successfully sent' : 'failed', ' with ', str_replace('Joli\JoliNotif\Driver\\', '', $driver::class), \PHP_EOL;

--- a/src/DefaultNotifier.php
+++ b/src/DefaultNotifier.php
@@ -34,7 +34,7 @@ class DefaultNotifier implements NotifierInterface
         ?LoggerInterface $logger = null,
         /** @var list<DriverInterface> $additionalDrivers */
         private readonly array $additionalDrivers = [],
-        private readonly bool $useOnlyAdditionalDrivers = false
+        private readonly bool $useOnlyAdditionalDrivers = false,
     ) {
         $this->logger = $logger ?? new NullLogger();
     }

--- a/src/Driver/AbstractCliBasedDriver.php
+++ b/src/Driver/AbstractCliBasedDriver.php
@@ -81,7 +81,7 @@ abstract class AbstractCliBasedDriver implements DriverInterface
         }
 
         $process = new Process(array_merge([$binary], $arguments));
-        $process->run();
+        $this->launchProcess($process);
 
         return $this->handleExitCode($process);
     }
@@ -123,6 +123,11 @@ abstract class AbstractCliBasedDriver implements DriverInterface
         $process->run();
 
         return $process->isSuccessful();
+    }
+
+    protected function launchProcess(Process $process): void
+    {
+        $process->run();
     }
 
     /**

--- a/src/Driver/AppleScriptDriver.php
+++ b/src/Driver/AppleScriptDriver.php
@@ -42,18 +42,18 @@ class AppleScriptDriver extends AbstractCliBasedDriver
 
     protected function getCommandLineArguments(Notification $notification): array
     {
-        $script = 'display notification "' . str_replace('"', '\\"', $notification->getBody() ?? '') . '"';
+        $script = 'display notification "' . str_replace('"', '\"', $notification->getBody() ?? '') . '"';
 
         if ($notification->getTitle()) {
-            $script .= ' with title "' . str_replace('"', '\\"', $notification->getTitle()) . '"';
+            $script .= ' with title "' . str_replace('"', '\"', $notification->getTitle()) . '"';
         }
 
         if ($notification->getOption('subtitle')) {
-            $script .= ' subtitle "' . str_replace('"', '\\"', (string) $notification->getOption('subtitle')) . '"';
+            $script .= ' subtitle "' . str_replace('"', '\"', (string) $notification->getOption('subtitle')) . '"';
         }
 
         if ($notification->getOption('sound')) {
-            $script .= ' sound name "' . str_replace('"', '\\"', (string) $notification->getOption('sound')) . '"';
+            $script .= ' sound name "' . str_replace('"', '\"', (string) $notification->getOption('sound')) . '"';
         }
 
         return [

--- a/src/Driver/NotifuDriver.php
+++ b/src/Driver/NotifuDriver.php
@@ -13,6 +13,7 @@ namespace Joli\JoliNotif\Driver;
 
 use Joli\JoliNotif\Notification;
 use JoliCode\PhpOsHelper\OsHelper;
+use Symfony\Component\Process\Process;
 
 /**
  * This driver can be used on Windows Seven and provides its own binaries if
@@ -70,5 +71,15 @@ class NotifuDriver extends AbstractCliBasedDriver implements BinaryProviderInter
         }
 
         return $arguments;
+    }
+
+    protected function launchProcess(Process $process): void
+    {
+        $process->start();
+    }
+
+    protected function handleExitCode(Process $process): bool
+    {
+        return true;
     }
 }

--- a/src/Driver/SnoreToastDriver.php
+++ b/src/Driver/SnoreToastDriver.php
@@ -75,8 +75,13 @@ class SnoreToastDriver extends AbstractCliBasedDriver implements BinaryProviderI
         return $arguments;
     }
 
+    protected function launchProcess(Process $process): void
+    {
+        $process->start();
+    }
+
     protected function handleExitCode(Process $process): bool
     {
-        return 0 < $process->getExitCode();
+        return true;
     }
 }

--- a/src/Exception/InvalidNotificationException.php
+++ b/src/Exception/InvalidNotificationException.php
@@ -21,7 +21,7 @@ class InvalidNotificationException extends \LogicException implements ExceptionI
         Notification $notification,
         string $message = '',
         int $code = 0,
-        ?\Throwable $previous = null
+        ?\Throwable $previous = null,
     ) {
         $this->notification = $notification;
 

--- a/src/Exception/NoSupportedNotifierException.php
+++ b/src/Exception/NoSupportedNotifierException.php
@@ -21,7 +21,7 @@ class NoSupportedNotifierException extends \RuntimeException implements Exceptio
     public function __construct(
         string $message = 'No supported notifier',
         int $code = 0,
-        ?\Throwable $previous = null
+        ?\Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
This PR is related to https://github.com/jolicode/JoliNotif/issues/111 

This PR is made to allow displaying a notification in a non blocking way.
The program will display the notification and continue executing without waiting for the notification to close.

This PR adds a new protected method `launchProcess()` with a purpose of running / starting the process responsible for sending the notification.
Since this is a protected method, it will not change the public interface and will just be used as a hook for developers that want to alter the behavior of how the process is launched by overriding it and use `$process->start()` instead of `$process->run()`
