### PR TITLE
LibNotifyDriver: Load lib over FFI only once

### DIFF
--- a/src/Driver/LibNotifyDriver.php
+++ b/src/Driver/LibNotifyDriver.php
@@ -26,14 +26,7 @@ class LibNotifyDriver implements DriverInterface
 {
     private const APP_NAME = 'JoliNotif';
 
-    private \FFI $ffi;
-
-    public function __destruct()
-    {
-        if (isset($this->ffi)) {
-            $this->ffi->notify_uninit();
-        }
-    }
+    private static \FFI $ffi;
 
     public static function isLibraryExists(): bool
     {
@@ -61,20 +54,20 @@ class LibNotifyDriver implements DriverInterface
         }
 
         $this->initialize();
-        $notification = $this->ffi->notify_notification_new(
+        $notification = self::$ffi->notify_notification_new(
             $notification->getTitle() ?? '',
             $notification->getBody(),
             $notification->getIcon()
         );
-        $value = $this->ffi->notify_notification_show($notification, null);
-        $this->ffi->g_object_unref($notification);
+        $value = self::$ffi->notify_notification_show($notification, null);
+        self::$ffi->g_object_unref($notification);
 
         return $value;
     }
 
-    private function initialize(): void
+    private static function initialize(): void
     {
-        if (isset($this->ffi)) {
+        if (isset(self::$ffi)) {
             return;
         }
 
@@ -90,13 +83,13 @@ class LibNotifyDriver implements DriverInterface
             throw new FFIRuntimeException('Unable to load libnotify');
         }
 
-        $this->ffi = $ffi;
+        self::$ffi = $ffi;
 
-        if (!$this->ffi->notify_init(self::APP_NAME)) {
+        if (!self::$ffi->notify_init(self::APP_NAME)) {
             throw new FFIRuntimeException('Unable to initialize libnotify');
         }
 
-        if (!$this->ffi->notify_is_initted()) {
+        if (!self::$ffi->notify_is_initted()) {
             throw new FFIRuntimeException('Libnotify has not been initialized');
         }
     }

--- a/tests/Driver/LibNotifyDriverTest.php
+++ b/tests/Driver/LibNotifyDriverTest.php
@@ -102,6 +102,27 @@ class LibNotifyDriverTest extends AbstractDriverTestCase
         $this->assertTrue($driver->send($notification));
     }
 
+    /**
+     * @requires extension ffi
+     */
+    public function testWithMultipleInstance()
+    {
+        $notification = (new Notification())
+            ->setBody('I\'m the notification body')
+            ->setTitle('I\'m the notification title')
+        ;
+
+        $result = (new LibNotifyDriver())->send($notification);
+
+        if (!$result) {
+            $this->markTestSkipped('Notification was not sent');
+        }
+
+        $this->assertTrue($result);
+        $this->assertTrue((new LibNotifyDriver())->send($notification));
+        $this->assertTrue((new LibNotifyDriver())->send($notification));
+    }
+
     protected function getDriver(): DriverInterface
     {
         static $driver;


### PR DESCRIPTION
refs #120

It's hard to test because there are some side effect in the PHP shutdown function.
And PHPUnit register some function at shutdown :( 

Maybe we should test that with a PHPT test.
Anyway, before / after

```
>…ire/dev/github.com/jolicode/JoliNotif(ffi *+) ./vendor/bin/simple-phpunit  --filter testWithMultipleInstance                                                                              
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.                                                                                                                                      
                                                                                                                                                                                            
Testing                                                                                                                                                                                     
                                                                                                                                                                                            
(process:384055): GLib-GObject-WARNING **: 18:21:23.120: cannot register existing type 'NotifyNotification'                                                                                 
                                                                                                                                                                                            
(process:384055): GLib-CRITICAL **: 18:21:23.120: g_once_init_leave: assertion 'result != 0' failed                                                                                         
                                                                                                                                                                                            
(process:384055): GLib-GObject-CRITICAL **: 18:21:23.120: g_object_new_valist: assertion 'G_TYPE_IS_OBJECT (object_type)' failed                                                            
                                                                                                                                                                                            
(process:384055): libnotify-CRITICAL **: 18:21:23.120: notify_notification_show: assertion 'notification != NULL' failed                                                                    
                                                                                                                                                                                            
(process:384055): GLib-GObject-CRITICAL **: 18:21:23.120: g_object_unref: assertion 'G_IS_OBJECT (object)' failed                                                                           
F                                                                   1 / 1 (100%)                                                                                                            
                                                                                                                                                                                            
Time: 00:00.014, Memory: 4.00 MB                                                                                                                                                            
                                                                                                                                                                                            
There was 1 failure:                                                                                                                                                                        
                                                                                                                                                                                            
1) Joli\JoliNotif\tests\Driver\LibNotifyDriverTest::testWithMultipleInstance                                                                                                                
Failed asserting that false is true.                                                                                                                                                        
                                                                                                                                                                                            
/home/gregoire/dev/github.com/jolicode/JoliNotif/tests/Driver/LibNotifyDriverTest.php:116                                                                                                   
                                                                                                                                                                                            
FAILURES!                                                                                                                                                                                   
Tests: 1, Assertions: 2, Failures: 1.

```
```
>…ire/dev/github.com/jolicode/JoliNotif(ffi *+) ./vendor/bin/simple-phpunit  --filter testWithMultipleInstance                                                                              
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.                                                                                                                                      
                                                                                                                                                                                            
Testing                                                                                                                                                                                     
.                                                                   1 / 1 (100%)                                                                                                            
                                                                                                                                                                                            
Time: 00:00.019, Memory: 4.00 MB                                                                                                                                                            
                                                                                                                                                                                            
OK (1 test, 3 assertions)                                
```
