### PR TITLE
Do not use FFI on SAPI !== cli

### DIFF
--- a/src/Driver/LibNotifyDriver.php
+++ b/src/Driver/LibNotifyDriver.php
@@ -36,9 +36,10 @@ class LibNotifyDriver implements DriverInterface
 
     public function isSupported(): bool
     {
-        return OsHelper::isUnix()
-            && !OsHelper::isMacOS()
+        return 'cli' === \PHP_SAPI
             && class_exists(\FFI::class)
+            && OsHelper::isUnix()
+            && !OsHelper::isMacOS()
             && self::isLibraryExists();
     }
 


### PR DESCRIPTION
We did that because there are some issue in FFI, where a state is kept

fixes https://github.com/jolicode/JoliNotif/issues/120
