### PR TITLE
Require PHP 8.3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It works on Linux, Windows (WSL included) or macOS.
     <img src=doc/images/demo.gif alt="JoliNotif demo" />
 </p>
 
-Requires PHP >= 8.2 (support for previous PHP versions was available in older releases of this library).
+Requires PHP >= 8.3 (support for previous PHP versions was available in older releases of this library).
 
 > [!NOTE]
 > This library can not be used in a web context (FPM or equivalent). Use


### PR DESCRIPTION
## Summary

The current package requires PHP 8.3 or newer, but the README still advertises PHP 8.2 support. This updates the existing requirement sentence to match `composer.json`, the 3.3.0 changelog, and the minimum CI job.

## Verification

- Confirmed both README and Composer now report `>=8.3`
- `composer validate --strict --no-check-publish`
- `castor cs --dry-run`
- `castor phpstan`
- Portable PHPUnit coverage passed; the remaining macOS-only cases require Linux `libnotify.so.4` or encode Linux `/tmp` paths in their expected PowerShell payloads

